### PR TITLE
Rewrite README and add MIT License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Notopress Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,34 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Notopress
 
-## Getting Started
+> [!CAUTION]
+> This project is currently under active development. Expect breaking changes and potential backward incompatibility as we evolve.
 
-First, run the development server:
+Notopress is a modern tool for building markdown-based, content-driven websites. Whether you're creating technical documentation, a personal blog, or high-performance marketing pages, Notopress provides a streamlined workflow to turn your markdown files into a polished web presence.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+## Features & Scenarios
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Notopress is designed to be flexible and fit into your existing writing workflow:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- **Obsidian Integration**: Manage your entire site directly from your Obsidian vault.
+- **Manual Control**: Simply write and organize your markdown files manually in your preferred editor.
+- **AI-Assisted Publishing**: Grant AI agents access to your content vaults to generate or refine articles with ease.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Requirements
 
-## Learn More
+To get started with Notopress, you will need:
 
-To learn more about Next.js, take a look at the following resources:
+- **Node.js Runtime**: A modern Node.js environment to host and run the application.
+- **S3-Compatible Storage**: Any S3-compatible service (like AWS S3, R2, or MinIO) to store and serve your content assets.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Roadmap
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+We are constantly working to improve Notopress. Here is what's on our immediate horizon:
 
-## Deploy on Vercel
+- [ ] **Localization**: Support for multi-language sites and easy translation workflows.
+- [ ] **Multi-site Support**: Manage multiple distinct websites from a single Notopress instance.
+- [ ] **Responsive Images**: Automatic image optimization and responsive sizing for faster page loads.
+- [ ] **Customizable Themes**: Flexible theming system to make your site look exactly how you want.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## License
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.


### PR DESCRIPTION
This PR replaces the default Next.js boilerplate documentation with project-specific information for Notopress. It outlines the tool's purpose, requirements, and usage scenarios. Additionally, it adds a roadmap for future features and an MIT license file.

Fixes #2

---
*PR created automatically by Jules for task [1940937495138683261](https://jules.google.com/task/1940937495138683261) started by @speshiou*