### PR TITLE
Refactor registry credentials and sync paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# Cloudflare R2 Credentials
+R2_ACCOUNT_ID=your-cloudflare-account-id
+R2_ACCESS_KEY_ID=your-r2-access-key-id
+R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+R2_BUCKET_NAME=your-r2-bucket-name
+
 # The absolute or relative path to the registry JSON file.
 # Defaults to ./registry.json if not specified.
 # REGISTRY_PATH=/path/to/your/registry.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
@@ -72,7 +71,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2251,6 +2249,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -2661,7 +2682,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2672,7 +2692,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2732,7 +2751,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3371,7 +3389,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3725,7 +3742,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4071,19 +4087,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4382,7 +4385,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4568,7 +4570,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6849,7 +6850,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6859,7 +6859,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7643,7 +7642,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7725,7 +7723,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -7837,7 +7834,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7978,7 +7974,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8324,7 +8319,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/registry.json.example
+++ b/registry.json.example
@@ -1,13 +1,9 @@
 {
-  "accountId": "your-cloudflare-account-id",
-  "accessKeyId": "your-r2-access-key-id",
-  "secretAccessKey": "your-r2-secret-access-key",
   "sites": [
     {
       "domain": "example.com",
       "siteId": "example-blog",
-      "vaultPath": "/absolute/path/to/your/obsidian/vault",
-      "bucketName": "your-r2-bucket-name"
+      "vaultPath": "/absolute/path/to/your/obsidian/vault"
     }
   ]
 }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -80,6 +80,19 @@ async function main() {
   const registry = getRegistry();
   const isDryRun = process.argv.includes('--dry-run');
 
+  const {
+    R2_ACCOUNT_ID,
+    R2_ACCESS_KEY_ID,
+    R2_SECRET_ACCESS_KEY,
+    R2_BUCKET_NAME,
+    REGISTRY_PATH
+  } = process.env;
+
+  if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_BUCKET_NAME) {
+    console.error('⨯ Error: Missing required environment variables: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME');
+    process.exit(1);
+  }
+
   if (isDryRun) {
     console.log('\n🏜️  DRY RUN MODE ENABLED - No changes will be made.');
   }
@@ -89,18 +102,13 @@ async function main() {
     choices: registry.sites.map(site => ({
       name: `${site.siteId} (${site.domain})`,
       value: site.siteId,
-      description: `Vault: ${site.vaultPath} -> Bucket: ${site.bucketName || 'Not configured'}`,
+      description: `Vault: ${site.vaultPath}`,
     })),
   });
 
   const site = registry.sites.find(s => s.siteId === siteId);
   if (!site) {
     console.error('⨯ Site not found in registry.json');
-    process.exit(1);
-  }
-
-  if (!site.bucketName) {
-    console.error(`⨯ Error: "bucketName" is not configured for site [${site.siteId}] in registry.json`);
     process.exit(1);
   }
 
@@ -114,35 +122,45 @@ async function main() {
 
   console.log(`\n☁️  Preparing AWS S3 Sync to Cloudflare R2...`);
   console.log(`- Local Path: ${site.vaultPath}`);
-  console.log(`- R2 Bucket:  ${site.bucketName}`);
-  console.log(`- Account ID: ${registry.accountId}\n`);
+  console.log(`- R2 Bucket:  ${R2_BUCKET_NAME}/${site.siteId}`);
+  console.log(`- Account ID: ${R2_ACCOUNT_ID}\n`);
 
   try {
-    // We add a trailing slash to the vaultPath so that aws s3 sync syncs the *contents* of the directory
-    // and not the directory itself.
+    const env = {
+      ...process.env,
+      AWS_ACCESS_KEY_ID: R2_ACCESS_KEY_ID,
+      AWS_SECRET_ACCESS_KEY: R2_SECRET_ACCESS_KEY
+    };
+
+    // 1. Sync site content to s3://bucket/siteId/
     const syncCommand = [
       'aws s3 sync',
       `"${site.vaultPath}/"`,
-      `"s3://${site.bucketName}/"`,
-      `--endpoint-url "https://${registry.accountId}.r2.cloudflarestorage.com"`,
+      `"s3://${R2_BUCKET_NAME}/${site.siteId}/"`,
+      `--endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"`,
       `--exclude "*.DS_Store"`,
       `--exclude "*/.git/*"`,
       `--exclude ".git/*"`,
-      `--delete`, // Automatically delete remote files that don't exist locally
+      `--delete`,
       isDryRun ? '--dryrun' : ''
     ].filter(Boolean).join(' ');
 
     console.log(`Executing:\n> ${syncCommand}\n`);
+    execSync(syncCommand, { stdio: 'inherit', env });
 
-    // stdio: 'inherit' passes the aws-cli output directly to our terminal
-    execSync(syncCommand, {
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        AWS_ACCESS_KEY_ID: registry.accessKeyId,
-        AWS_SECRET_ACCESS_KEY: registry.secretAccessKey
-      }
-    });
+    // 2. Sync registry.json to s3://bucket/registry.json
+    const registryFilePath = REGISTRY_PATH || join(process.cwd(), 'registry.json');
+    const syncRegistryCommand = [
+      'aws s3 cp',
+      `"${registryFilePath}"`,
+      `"s3://${R2_BUCKET_NAME}/registry.json"`,
+      `--endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"`,
+      isDryRun ? '--dryrun' : ''
+    ].filter(Boolean).join(' ');
+
+    console.log(`\n☁️  Syncing registry.json to bucket root...`);
+    console.log(`Executing:\n> ${syncRegistryCommand}\n`);
+    execSync(syncRegistryCommand, { stdio: 'inherit', env });
 
     if (isDryRun) {
       console.log('\n✅ Dry run completed successfully!');

--- a/src/domain/registry.ts
+++ b/src/domain/registry.ts
@@ -4,13 +4,9 @@ export const SiteSchema = z.object({
   domain: z.string(),
   siteId: z.string(),
   vaultPath: z.string(),
-  bucketName: z.string().optional(),
 });
 
 export const RegistrySchema = z.object({
-  accountId: z.string(),
-  accessKeyId: z.string(),
-  secretAccessKey: z.string(),
   sites: z.array(SiteSchema),
 });
 


### PR DESCRIPTION
This PR refactors the site registry system to improve security and standardize storage paths.

### Changes:
1.  **Credential Management**: R2 credentials (`accountId`, `accessKeyId`, `secretAccessKey`) and the target `bucketName` are now managed exclusively through environment variables (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`).
2.  **Schema Update**: The `RegistrySchema` and `SiteSchema` in `src/domain/registry.ts` have been updated to reflect these changes.
3.  **Sync Script Enhancements**:
    - `scripts/sync.ts` now uses the environment variables.
    - Each site's content is synced to `s3://${R2_BUCKET_NAME}/${siteId}/` instead of its own bucket.
    - `registry.json` is automatically synced to `s3://${R2_BUCKET_NAME}/registry.json` after site content sync.
4.  **Documentation**: Updated `registry.json.example` and `.env.example` to guide users on the new configuration format.

These changes centralize sensitive configuration and simplify multi-site management.

Fixes #8

---
*PR created automatically by Jules for task [16993211743401887901](https://jules.google.com/task/16993211743401887901) started by @speshiou*