### PR TITLE
Sync entire vault to site-specific subdirectory and support env var credentials

### DIFF
--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -1,7 +1,7 @@
 import { select } from '@inquirer/prompts';
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync, unlinkSync, opendirSync } from 'fs';
 import { execSync } from 'child_process';
-import { join, basename, extname } from 'path';
+import { join, basename, extname, relative } from 'path';
 import { getRegistry } from '../src/lib/registry';
 
 
@@ -12,67 +12,104 @@ interface PostMetadata {
   excerpt: string;
 }
 
+function scanMarkdownFiles(dir: string, baseDir: string = dir): PostMetadata[] {
+  const posts: PostMetadata[] = [];
+
+  function walk(currentDir: string) {
+    const entries = readdirSync(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name !== '.git' && entry.name !== 'node_modules') {
+          walk(fullPath);
+        }
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        const content = readFileSync(fullPath, 'utf-8');
+        const stats = statSync(fullPath);
+
+        // Extract Title: First H1
+        const titleMatch = content.match(/^#\s+(.+)$/m);
+        const title = titleMatch ? titleMatch[1].trim() : entry.name;
+
+        // Extract Slug: relative path without extension
+        const relPath = relative(baseDir, fullPath);
+        const slug = join(
+          relPath.slice(0, relPath.length - extname(relPath).length)
+        );
+
+        // Date: last modified time
+        const date = stats.mtime.toISOString();
+
+        // Excerpt: First non-title, non-empty paragraph (truncated)
+        const firstParagraph = content
+          .split('\n')
+          .map(line => line.trim())
+          .filter(line => line && !line.startsWith('#') && !line.startsWith('>'))
+          [0];
+
+        let excerpt = '';
+        if (firstParagraph) {
+          excerpt = firstParagraph.slice(0, 160);
+          if (firstParagraph.length > 160) {
+            excerpt += '...';
+          }
+        }
+
+        posts.push({ title, slug, date, excerpt });
+      }
+    }
+  }
+
+  walk(dir);
+
+  // Sort by date descending
+  return posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
 function generateIndex(vaultPath: string, dryRun: boolean = false) {
   const postsBaseDir = join(vaultPath, 'posts');
-  if (!existsSync(postsBaseDir)) {
-    console.warn(`⚠️  Warning: "posts" directory not found in vault: ${postsBaseDir}. Skipping index generation.`);
-    return;
-  }
 
-  // Get all locale directories (en, ja, zh-hant, etc.)
-  const locales = readdirSync(postsBaseDir).filter(dir => {
-    return statSync(join(postsBaseDir, dir)).isDirectory();
-  });
+  if (existsSync(postsBaseDir)) {
+    // Legacy behavior: Get all locale directories (en, ja, zh-hant, etc.)
+    const locales = readdirSync(postsBaseDir).filter(dir => {
+      return statSync(join(postsBaseDir, dir)).isDirectory();
+    });
 
-  if (locales.length === 0) {
-    console.warn(`⚠️  No locale directories found in ${postsBaseDir}`);
-    return;
-  }
+    if (locales.length > 0) {
+      for (const locale of locales) {
+        const postsDir = join(postsBaseDir, locale);
+        const posts = scanMarkdownFiles(postsDir);
 
-  for (const locale of locales) {
-    const postsDir = join(postsBaseDir, locale);
-    const files = readdirSync(postsDir).filter(f => f.endsWith('.md'));
+        if (posts.length === 0) continue;
 
-    if (files.length === 0) continue;
-
-    console.log(`\n🔍 Scanning [${locale}] posts in ${postsDir}...`);
-    const posts: PostMetadata[] = [];
-
-    for (const file of files) {
-      const filePath = join(postsDir, file);
-      const content = readFileSync(filePath, 'utf-8');
-      const stats = statSync(filePath);
-
-      // Extract Title: First H1
-      const titleMatch = content.match(/^#\s+(.+)$/m);
-      const title = titleMatch ? titleMatch[1].trim() : file;
-
-      // Extract Slug: Filename without extension
-      const slug = basename(file, extname(file));
-
-      // Date: last modified time
-      const date = stats.mtime.toISOString();
-
-      // Excerpt: First non-title, non-empty paragraph (truncated)
-      const excerpt = content
-        .split('\n')
-        .map(line => line.trim())
-        .filter(line => line && !line.startsWith('#') && !line.startsWith('>'))
-      [0]?.slice(0, 160) + '...' || '';
-
-      posts.push({ title, slug, date, excerpt });
+        const indexPath = join(postsDir, 'index.json');
+        if (dryRun) {
+          console.log(`[DRY RUN] Would generate [${locale}] index with ${posts.length} posts at: ${indexPath}`);
+        } else {
+          writeFileSync(indexPath, JSON.stringify(posts, null, 2));
+          console.log(`✨ Generated [${locale}] index with ${posts.length} posts at: ${indexPath}`);
+        }
+      }
+      return;
     }
+  }
 
-    // Sort by date descending
-    posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  // New behavior: scan vault root if no posts/locale structure
+  console.log(`\n🔍 Scanning vault root for markdown files in ${vaultPath}...`);
+  const posts = scanMarkdownFiles(vaultPath);
 
-    const indexPath = join(postsDir, 'index.json');
+  if (posts.length > 0) {
+    const indexPath = join(vaultPath, 'index.json');
     if (dryRun) {
-      console.log(`[DRY RUN] Would generate [${locale}] index with ${posts.length} posts at: ${indexPath}`);
+      console.log(`[DRY RUN] Would generate vault index with ${posts.length} posts at: ${indexPath}`);
     } else {
       writeFileSync(indexPath, JSON.stringify(posts, null, 2));
-      console.log(`✨ Generated [${locale}] index with ${posts.length} posts at: ${indexPath}`);
+      console.log(`✨ Generated vault index with ${posts.length} posts at: ${indexPath}`);
     }
+  } else {
+    console.warn(`⚠️  No markdown files found in vault: ${vaultPath}. Skipping index generation.`);
   }
 }
 
@@ -112,19 +149,29 @@ async function main() {
   // Generate index.json at the vault root before syncing
   generateIndex(site.vaultPath, isDryRun);
 
+  const accountId = registry.accountId || process.env.R2_ACCOUNT_ID;
+  const accessKeyId = registry.accessKeyId || process.env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = registry.secretAccessKey || process.env.R2_SECRET_ACCESS_KEY;
+
+  if (!accountId || !accessKeyId || !secretAccessKey) {
+    console.error('⨯ Error: Missing R2 credentials. Please provide them in registry.json or via environment variables (R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY).');
+    process.exit(1);
+  }
+
   console.log(`\n☁️  Preparing AWS S3 Sync to Cloudflare R2...`);
   console.log(`- Local Path: ${site.vaultPath}`);
   console.log(`- R2 Bucket:  ${site.bucketName}`);
-  console.log(`- Account ID: ${registry.accountId}\n`);
+  console.log(`- Account ID: ${accountId}\n`);
 
   try {
     // We add a trailing slash to the vaultPath so that aws s3 sync syncs the *contents* of the directory
     // and not the directory itself.
+    // Each site is synced to its own subdirectory in the bucket: /{site-id}/*
     const syncCommand = [
       'aws s3 sync',
       `"${site.vaultPath}/"`,
-      `"s3://${site.bucketName}/"`,
-      `--endpoint-url "https://${registry.accountId}.r2.cloudflarestorage.com"`,
+      `"s3://${site.bucketName}/${site.siteId}/"`,
+      `--endpoint-url "https://${accountId}.r2.cloudflarestorage.com"`,
       `--exclude "*.DS_Store"`,
       `--exclude "*/.git/*"`,
       `--exclude ".git/*"`,
@@ -139,15 +186,51 @@ async function main() {
       stdio: 'inherit',
       env: {
         ...process.env,
-        AWS_ACCESS_KEY_ID: registry.accessKeyId,
-        AWS_SECRET_ACCESS_KEY: registry.secretAccessKey
+        AWS_ACCESS_KEY_ID: accessKeyId,
+        AWS_SECRET_ACCESS_KEY: secretAccessKey
       }
     });
 
     if (isDryRun) {
       console.log('\n✅ Dry run completed successfully!');
     } else {
-      console.log('\n✅ Sync successfully completed!');
+      console.log('\n✨ Uploading sanitized registry.json to bucket root...');
+
+      // Sanitize registry: remove sensitive credentials and local vault paths
+      const sanitizedSites = registry.sites
+        .filter(s => s.bucketName === site.bucketName)
+        .map(s => ({
+          domain: s.domain,
+          siteId: s.siteId,
+          // vaultPath is omitted or can be a placeholder
+        }));
+
+      const sanitizedRegistry = {
+        sites: sanitizedSites
+      };
+
+      const registryTmpPath = join(process.cwd(), 'registry.sanitized.json');
+      writeFileSync(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
+
+      const uploadRegistryCommand = [
+        'aws s3 cp',
+        `"${registryTmpPath}"`,
+        `"s3://${site.bucketName}/registry.json"`,
+        `--endpoint-url "https://${accountId}.r2.cloudflarestorage.com"`,
+      ].join(' ');
+
+      execSync(uploadRegistryCommand, {
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          AWS_ACCESS_KEY_ID: accessKeyId,
+          AWS_SECRET_ACCESS_KEY: secretAccessKey
+        }
+      });
+
+      unlinkSync(registryTmpPath);
+
+      console.log('\n✅ Sync and registry upload successfully completed!');
     }
 
   } catch (err: any) {

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -1,7 +1,8 @@
 import { select } from '@inquirer/prompts';
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync, unlinkSync, opendirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync, unlinkSync } from 'fs';
 import { execSync } from 'child_process';
 import { join, basename, extname, relative } from 'path';
+import { tmpdir } from 'os';
 import { getRegistry } from '../src/lib/registry';
 
 
@@ -35,9 +36,7 @@ function scanMarkdownFiles(dir: string, baseDir: string = dir): PostMetadata[] {
 
         // Extract Slug: relative path without extension
         const relPath = relative(baseDir, fullPath);
-        const slug = join(
-          relPath.slice(0, relPath.length - extname(relPath).length)
-        );
+        const slug = relPath.slice(0, relPath.length - extname(relPath).length);
 
         // Date: last modified time
         const date = stats.mtime.toISOString();
@@ -209,26 +208,30 @@ async function main() {
         sites: sanitizedSites
       };
 
-      const registryTmpPath = join(process.cwd(), 'registry.sanitized.json');
-      writeFileSync(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
+      const registryTmpPath = join(tmpdir(), `registry.sanitized.${Date.now()}.json`);
+      try {
+        writeFileSync(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
 
-      const uploadRegistryCommand = [
-        'aws s3 cp',
-        `"${registryTmpPath}"`,
-        `"s3://${site.bucketName}/registry.json"`,
-        `--endpoint-url "https://${accountId}.r2.cloudflarestorage.com"`,
-      ].join(' ');
+        const uploadRegistryCommand = [
+          'aws s3 cp',
+          `"${registryTmpPath}"`,
+          `"s3://${site.bucketName}/registry.json"`,
+          `--endpoint-url "https://${accountId}.r2.cloudflarestorage.com"`,
+        ].join(' ');
 
-      execSync(uploadRegistryCommand, {
-        stdio: 'inherit',
-        env: {
-          ...process.env,
-          AWS_ACCESS_KEY_ID: accessKeyId,
-          AWS_SECRET_ACCESS_KEY: secretAccessKey
+        execSync(uploadRegistryCommand, {
+          stdio: 'inherit',
+          env: {
+            ...process.env,
+            AWS_ACCESS_KEY_ID: accessKeyId,
+            AWS_SECRET_ACCESS_KEY: secretAccessKey
+          }
+        });
+      } finally {
+        if (existsSync(registryTmpPath)) {
+          unlinkSync(registryTmpPath);
         }
-      });
-
-      unlinkSync(registryTmpPath);
+      }
 
       console.log('\n✅ Sync and registry upload successfully completed!');
     }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -1,9 +1,20 @@
 import { select } from '@inquirer/prompts';
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync, unlinkSync } from 'fs';
+import { readFile, writeFile, readdir, stat, unlink, access } from 'fs/promises';
+import { constants } from 'fs';
 import { execSync } from 'child_process';
 import { join, basename, extname, relative } from 'path';
 import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
 import { getRegistry } from '../src/lib/registry';
+
+async function exists(path: string) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 
 interface PostMetadata {
@@ -13,22 +24,22 @@ interface PostMetadata {
   excerpt: string;
 }
 
-function scanMarkdownFiles(dir: string, baseDir: string = dir): PostMetadata[] {
+async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<PostMetadata[]> {
   const posts: PostMetadata[] = [];
 
-  function walk(currentDir: string) {
-    const entries = readdirSync(currentDir, { withFileTypes: true });
+  async function walk(currentDir: string) {
+    const entries = await readdir(currentDir, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = join(currentDir, entry.name);
 
       if (entry.isDirectory()) {
         if (entry.name !== '.git' && entry.name !== 'node_modules') {
-          walk(fullPath);
+          await walk(fullPath);
         }
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
-        const content = readFileSync(fullPath, 'utf-8');
-        const stats = statSync(fullPath);
+        const content = await readFile(fullPath, 'utf-8');
+        const fileStats = await stat(fullPath);
 
         // Extract Title: First H1
         const titleMatch = content.match(/^#\s+(.+)$/m);
@@ -36,10 +47,10 @@ function scanMarkdownFiles(dir: string, baseDir: string = dir): PostMetadata[] {
 
         // Extract Slug: relative path without extension
         const relPath = relative(baseDir, fullPath);
-        const slug = relPath.slice(0, relPath.length - extname(relPath).length);
+        const slug = relPath.replace(/\.md$/, '');
 
         // Date: last modified time
-        const date = stats.mtime.toISOString();
+        const date = fileStats.mtime.toISOString();
 
         // Excerpt: First non-title, non-empty paragraph (truncated)
         const firstParagraph = content
@@ -61,25 +72,24 @@ function scanMarkdownFiles(dir: string, baseDir: string = dir): PostMetadata[] {
     }
   }
 
-  walk(dir);
+  await walk(dir);
 
   // Sort by date descending
   return posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
-function generateIndex(vaultPath: string, dryRun: boolean = false) {
+async function generateIndex(vaultPath: string, dryRun: boolean = false) {
   const postsBaseDir = join(vaultPath, 'posts');
 
-  if (existsSync(postsBaseDir)) {
+  if (await exists(postsBaseDir)) {
     // Legacy behavior: Get all locale directories (en, ja, zh-hant, etc.)
-    const locales = readdirSync(postsBaseDir).filter(dir => {
-      return statSync(join(postsBaseDir, dir)).isDirectory();
-    });
+    const entries = await readdir(postsBaseDir, { withFileTypes: true });
+    const locales = entries.filter(entry => entry.isDirectory()).map(entry => entry.name);
 
     if (locales.length > 0) {
       for (const locale of locales) {
         const postsDir = join(postsBaseDir, locale);
-        const posts = scanMarkdownFiles(postsDir);
+        const posts = await scanMarkdownFiles(postsDir);
 
         if (posts.length === 0) continue;
 
@@ -87,7 +97,7 @@ function generateIndex(vaultPath: string, dryRun: boolean = false) {
         if (dryRun) {
           console.log(`[DRY RUN] Would generate [${locale}] index with ${posts.length} posts at: ${indexPath}`);
         } else {
-          writeFileSync(indexPath, JSON.stringify(posts, null, 2));
+          await writeFile(indexPath, JSON.stringify(posts, null, 2));
           console.log(`✨ Generated [${locale}] index with ${posts.length} posts at: ${indexPath}`);
         }
       }
@@ -97,14 +107,14 @@ function generateIndex(vaultPath: string, dryRun: boolean = false) {
 
   // New behavior: scan vault root if no posts/locale structure
   console.log(`\n🔍 Scanning vault root for markdown files in ${vaultPath}...`);
-  const posts = scanMarkdownFiles(vaultPath);
+  const posts = await scanMarkdownFiles(vaultPath);
 
   if (posts.length > 0) {
     const indexPath = join(vaultPath, 'index.json');
     if (dryRun) {
       console.log(`[DRY RUN] Would generate vault index with ${posts.length} posts at: ${indexPath}`);
     } else {
-      writeFileSync(indexPath, JSON.stringify(posts, null, 2));
+      await writeFile(indexPath, JSON.stringify(posts, null, 2));
       console.log(`✨ Generated vault index with ${posts.length} posts at: ${indexPath}`);
     }
   } else {
@@ -140,13 +150,13 @@ async function main() {
     process.exit(1);
   }
 
-  if (!existsSync(site.vaultPath)) {
+  if (!(await exists(site.vaultPath))) {
     console.error(`⨯ Error: The local vaultPath does not exist: ${site.vaultPath}`);
     process.exit(1);
   }
 
   // Generate index.json at the vault root before syncing
-  generateIndex(site.vaultPath, isDryRun);
+  await generateIndex(site.vaultPath, isDryRun);
 
   const accountId = registry.accountId || process.env.R2_ACCOUNT_ID;
   const accessKeyId = registry.accessKeyId || process.env.R2_ACCESS_KEY_ID;
@@ -208,9 +218,9 @@ async function main() {
         sites: sanitizedSites
       };
 
-      const registryTmpPath = join(tmpdir(), `registry.sanitized.${Date.now()}.json`);
+      const registryTmpPath = join(tmpdir(), `notopress-registry-${randomUUID()}.json`);
       try {
-        writeFileSync(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
+        await writeFile(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
 
         const uploadRegistryCommand = [
           'aws s3 cp',
@@ -228,8 +238,8 @@ async function main() {
           }
         });
       } finally {
-        if (existsSync(registryTmpPath)) {
-          unlinkSync(registryTmpPath);
+        if (await exists(registryTmpPath)) {
+          await unlink(registryTmpPath);
         }
       }
 

--- a/src/domain/registry.ts
+++ b/src/domain/registry.ts
@@ -8,9 +8,9 @@ export const SiteSchema = z.object({
 });
 
 export const RegistrySchema = z.object({
-  accountId: z.string(),
-  accessKeyId: z.string(),
-  secretAccessKey: z.string(),
+  accountId: z.string().optional(),
+  accessKeyId: z.string().optional(),
+  secretAccessKey: z.string().optional(),
   sites: z.array(SiteSchema),
 });
 


### PR DESCRIPTION
This change updates the sync process to be more flexible and secure. 
1. Credentials can now be provided via environment variables, allowing registry.json to be shared without sensitive info.
2. Each site is now synced to its own subdirectory (/{site-id}/*) in the R2 bucket, and a sanitized registry.json is uploaded to the bucket root.
3. The index generation logic has been improved to scan the entire vault recursively, supporting any directory structure and providing better excerpts.

Fixes #10

---
*PR created automatically by Jules for task [17100636118754038776](https://jules.google.com/task/17100636118754038776) started by @speshiou*