### PR TITLE
Refactor registry loading to support custom locations

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -56,7 +56,14 @@ async function main() {
     }
   }
 
-  const registry = await getRegistry();
+  // Parse registry path from command line arguments
+  let registryPath: string | undefined;
+  const registryIndex = process.argv.findIndex(arg => arg === '--registry' || arg === '-r');
+  if (registryIndex !== -1 && registryIndex + 1 < process.argv.length) {
+    registryPath = process.argv[registryIndex + 1];
+  }
+
+  const registry = await getRegistry(registryPath);
 
   const siteId = await select({
     message: 'Select a site to deploy to Vercel:',

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -3,6 +3,7 @@ import { spawn } from 'child_process';
 import { readFile, writeFile } from 'fs/promises';
 import { getRegistry } from '../src/lib/registry';
 import { ENV_KEYS, ENV_METADATA } from '../src/lib/env';
+import { hasFlag, getFlagValue } from '../src/lib/cli';
 
 function execAsync(command: string, options: any = {}): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -43,7 +44,7 @@ function spawnAsync(command: string, args: string[], options: any = {}): Promise
 }
 
 async function main() {
-  const isDev = process.argv.includes('--dev');
+  const isDev = hasFlag({ flag: '--dev' });
 
   // Check if vercel CLI is installed (only if NOT in dev mode)
   if (!isDev) {
@@ -57,11 +58,7 @@ async function main() {
   }
 
   // Parse registry path from command line arguments
-  let registryPath: string | undefined;
-  const registryIndex = process.argv.findIndex(arg => arg === '--registry' || arg === '-r');
-  if (registryIndex !== -1 && registryIndex + 1 < process.argv.length) {
-    registryPath = process.argv[registryIndex + 1];
-  }
+  const registryPath = getFlagValue({ flag: '--registry', alias: '-r' });
 
   const registry = await getRegistry(registryPath);
 

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -136,8 +136,16 @@ async function generateIndex(vaultPath: string, dryRun: boolean = false) {
 }
 
 async function main() {
-  const registry = await getRegistry();
   const isDryRun = process.argv.includes('--dry-run');
+
+  // Parse registry path from command line arguments
+  let registryPath: string | undefined;
+  const registryIndex = process.argv.findIndex(arg => arg === '--registry' || arg === '-r');
+  if (registryIndex !== -1 && registryIndex + 1 < process.argv.length) {
+    registryPath = process.argv[registryIndex + 1];
+  }
+
+  const registry = await getRegistry(registryPath);
 
   if (isDryRun) {
     console.log('\n🏜️  DRY RUN MODE ENABLED - No changes will be made.');

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -9,6 +9,7 @@ import { getRegistry } from '../src/lib/registry';
 import { env } from '../src/lib/env';
 import { INDEX_JSON } from '../src/lib/constants';
 import { PostMetadata, VaultIndex } from '../src/lib/vault';
+import { hasFlag, getFlagValue } from '../src/lib/cli';
 
 async function exists(path: string) {
   try {
@@ -138,14 +139,10 @@ async function generateIndex(vaultPath: string, dryRun: boolean = false) {
 }
 
 async function main() {
-  const isDryRun = process.argv.includes('--dry-run');
+  const isDryRun = hasFlag({ flag: '--dry-run' });
 
   // Parse registry path from command line arguments
-  let registryPath: string | undefined;
-  const registryIndex = process.argv.findIndex(arg => arg === '--registry' || arg === '-r');
-  if (registryIndex !== -1 && registryIndex + 1 < process.argv.length) {
-    registryPath = process.argv[registryIndex + 1];
-  }
+  const registryPath = getFlagValue({ flag: '--registry', alias: '-r' });
 
   const registry = await getRegistry(registryPath);
 

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -1,0 +1,22 @@
+/**
+ * Checks if a flag exists in process.argv
+ */
+export function hasFlag({ flag, alias }: { flag: string; alias?: string }): boolean {
+  return process.argv.some(arg => arg === flag || (alias && arg === alias));
+}
+
+/**
+ * Gets the value of a flag. If the flag is present but has no value,
+ * or the value starts with '-', it returns undefined.
+ */
+export function getFlagValue({ flag, alias }: { flag: string; alias?: string }): string | undefined {
+  const index = process.argv.findIndex(arg => arg === flag || (alias && arg === alias));
+  if (index === -1) return undefined;
+
+  const value = process.argv[index + 1];
+  if (value && !value.startsWith('-')) {
+    return value;
+  }
+
+  return undefined;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,3 +11,8 @@ export const INDEX_SLUG = 'index';
  * The filename for the generated post index of a vault.
  */
 export const INDEX_JSON = 'index.json';
+
+/**
+ * The default filename for the registry configuration.
+ */
+export const DEFAULT_REGISTRY_FILENAME = 'registry.json';

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,14 +1,15 @@
 import { readFile, access } from 'fs/promises';
 import path from 'path';
 import { RegistrySchema, type Registry } from '../domain/registry';
+import { DEFAULT_REGISTRY_FILENAME } from './constants';
 
 /**
  * Loads and validates the registry configuration.
- * The path can be overridden via the REGISTRY_PATH environment variable.
+ * The path can be overridden via parameter or REGISTRY_PATH environment variable.
  */
-export async function getRegistry(): Promise<Registry> {
-  const defaultPath = path.join(process.cwd(), 'registry.json');
-  const registryPath = process.env.REGISTRY_PATH || defaultPath;
+export async function getRegistry(customPath?: string): Promise<Registry> {
+  const defaultPath = path.join(process.cwd(), DEFAULT_REGISTRY_FILENAME);
+  const registryPath = customPath || process.env.REGISTRY_PATH || defaultPath;
 
   try {
     await access(registryPath);


### PR DESCRIPTION
This PR refactors the registry loading logic to support custom registry locations.

Changes:
1.  **Constants**: Added `DEFAULT_REGISTRY_FILENAME = 'registry.json'` in `src/lib/constants.ts`.
2.  **Registry Logic**: Updated `getRegistry` in `src/lib/registry.ts` to accept an optional `customPath`. It now prioritizes the provided path, then the `REGISTRY_PATH` environment variable, and finally the default constant.
3.  **CLI Scripts**: Updated `scripts/sync.ts` and `scripts/deploy.ts` to parse `--registry` or `-r` command-line arguments and pass them to `getRegistry`.

This allows users to specify an alternative registry file (e.g., for different environments or testing) without relying solely on environment variables or the default filename.

Fixes #18

---
*PR created automatically by Jules for task [3546546477760264630](https://jules.google.com/task/3546546477760264630) started by @speshiou*