### PR TITLE
Refactor vault structure and naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ To get started with Notopress, you will need:
 - **Node.js Runtime**: A modern Node.js environment to host and run the application.
 - **S3-Compatible Storage**: Any S3-compatible service (like AWS S3, R2, or MinIO) to store and serve your content assets.
 
+## Vault Structure
+
+Notopress requires your content vault to follow a specific directory structure:
+
+- **`content/` (Required)**: This directory contains all your markdown files.
+    - Directory indices must be named **`page.md`** (e.g., `blog/page.md` maps to `/blog`).
+    - The site home page must be located at **`content/page.md`**.
+- **`public/` (Optional)**: This directory contains static assets (images, PDFs, etc.) that will be served at the same path as they appear in the folder.
+
 ## Configuration
 
 Notopress uses a centralized registry to manage multiple sites and their respective storage configurations.
@@ -70,7 +79,7 @@ npm run sync -- --dry-run
 ```
 
 This will:
-- Preview the `index.json` generation for each locale.
+- Preview the `index.json` generation for the `content/` directory.
 - Show which files would be uploaded, updated, or deleted on the remote storage using the AWS CLI's `--dryrun` mode.
 
 ## Roadmap

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -7,8 +7,8 @@ import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { getRegistry } from '../src/lib/registry';
 import { env } from '../src/lib/env';
-import { INDEX_JSON } from '../src/lib/constants';
-import { PostMetadata, VaultIndex } from '../src/lib/vault';
+import { INDEX_JSON, INDEX_SLUG } from '../src/lib/constants';
+import { PageMetadata, VaultIndex } from '../src/lib/vault';
 import { hasFlag, getFlagValue } from '../src/lib/cli';
 
 async function exists(path: string) {
@@ -57,8 +57,8 @@ async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<stri
   return files;
 }
 
-async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<PostMetadata[]> {
-  const posts: PostMetadata[] = [];
+async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<PageMetadata[]> {
+  const pages: PageMetadata[] = [];
 
   async function walk(currentDir: string) {
     const entries = await readdir(currentDir, { withFileTypes: true });
@@ -100,7 +100,7 @@ async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<Po
           }
         }
 
-        posts.push({ title, slug, date, excerpt });
+        pages.push({ title, slug, date, excerpt });
       }
     }
   }
@@ -108,7 +108,7 @@ async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<Po
   await walk(dir);
 
   // Sort by date descending
-  return posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return pages.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
 async function generateIndex(vaultPath: string, dryRun: boolean = false) {
@@ -122,21 +122,26 @@ async function generateIndex(vaultPath: string, dryRun: boolean = false) {
 
   // Scan content directory for markdown files
   console.log(`\n🔍 Scanning vault "content" directory for markdown files in ${contentDir}...`);
-  const posts = await scanMarkdownFiles(contentDir);
+  const pages = await scanMarkdownFiles(contentDir);
 
-  if (posts.length > 0 || publicFiles.length > 0) {
+  const hasRootPage = pages.some(p => p.slug === INDEX_SLUG);
+  if (!hasRootPage) {
+    console.warn(`⚠️  Warning: No root content page found at content/${INDEX_SLUG}.md. The site home page will fallback to a collection view of all pages.`);
+  }
+
+  if (pages.length > 0 || publicFiles.length > 0) {
     const indexPath = join(vaultPath, INDEX_JSON);
     const vaultIndex: VaultIndex = {
       version: 1,
-      posts,
+      pages,
       publicFiles,
     };
 
     if (dryRun) {
-      console.log(`[DRY RUN] Would generate vault index with ${posts.length} posts and ${publicFiles.length} public files at: ${indexPath}`);
+      console.log(`[DRY RUN] Would generate vault index with ${pages.length} pages and ${publicFiles.length} public files at: ${indexPath}`);
     } else {
       await writeFile(indexPath, JSON.stringify(vaultIndex, null, 2));
-      console.log(`✨ Generated vault index with ${posts.length} posts and ${publicFiles.length} public files at: ${indexPath}`);
+      console.log(`✨ Generated vault index with ${pages.length} pages and ${publicFiles.length} public files at: ${indexPath}`);
     }
   } else {
     console.warn(`⚠️  No markdown files or public files found in vault: ${vaultPath}. Skipping index generation.`);

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -48,7 +48,7 @@ async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<stri
         }
       } else if (entry.isFile()) {
         const relPath = relative(baseDir, fullPath);
-        files.push(relPath);
+        files.push(relPath.replace(/\\/g, '/'));
       }
     }
   }
@@ -80,7 +80,7 @@ async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<Pa
 
         // Extract Slug: relative path without extension
         const relPath = relative(baseDir, fullPath);
-        const slug = relPath.replace(/\.md$/, '');
+        const slug = relPath.replace(/\.md$/, '').replace(/\\/g, '/');
 
         // Date: last modified time
         const date = fileStats.mtime.toISOString();

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -67,7 +67,7 @@ async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<Po
       const fullPath = join(currentDir, entry.name);
 
       if (entry.isDirectory()) {
-        if (entry.name !== '.git' && entry.name !== 'node_modules' && entry.name !== 'public') {
+        if (entry.name !== '.git' && entry.name !== 'node_modules') {
           await walk(fullPath);
         }
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
@@ -113,11 +113,16 @@ async function scanMarkdownFiles(dir: string, baseDir: string = dir): Promise<Po
 
 async function generateIndex(vaultPath: string, dryRun: boolean = false) {
   const publicBaseDir = join(vaultPath, 'public');
-  const publicFiles = await scanPublicFiles(publicBaseDir);
+  const publicFiles = await exists(publicBaseDir) ? await scanPublicFiles(publicBaseDir) : [];
 
-  // Scan vault root for markdown files
-  console.log(`\n🔍 Scanning vault root for markdown files in ${vaultPath}...`);
-  const posts = await scanMarkdownFiles(vaultPath);
+  const contentDir = join(vaultPath, 'content');
+  if (!(await exists(contentDir))) {
+    throw new Error(`⨯ Error: The required "content" directory is missing in the vault: ${vaultPath}`);
+  }
+
+  // Scan content directory for markdown files
+  console.log(`\n🔍 Scanning vault "content" directory for markdown files in ${contentDir}...`);
+  const posts = await scanMarkdownFiles(contentDir);
 
   if (posts.length > 0 || publicFiles.length > 0) {
     const indexPath = join(vaultPath, INDEX_JSON);

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -117,7 +117,8 @@ async function generateIndex(vaultPath: string, dryRun: boolean = false) {
 
   const contentDir = join(vaultPath, 'content');
   if (!(await exists(contentDir))) {
-    throw new Error(`⨯ Error: The required "content" directory is missing in the vault: ${vaultPath}`);
+    console.error(`⨯ Error: The required "content" directory is missing in the vault: ${vaultPath}`);
+    process.exit(1);
   }
 
   // Scan content directory for markdown files

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -34,7 +34,7 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
               ← Home
             </Link>
           </nav>
-          <article 
+          <article
             className="prose prose-zinc dark:prose-invert prose-lg max-w-none 
               prose-headings:font-semibold prose-headings:tracking-tight prose-headings:text-zinc-900 dark:prose-headings:text-zinc-100
               prose-p:leading-8 prose-p:text-zinc-600 dark:prose-p:text-zinc-400
@@ -43,7 +43,7 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
               prose-code:text-zinc-800 dark:prose-code:text-zinc-300 prose-code:bg-zinc-100 dark:prose-code:bg-zinc-900/50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none
               prose-img:rounded-3xl prose-img:shadow-2xl prose-img:mx-auto prose-img:border prose-img:border-zinc-100 dark:prose-img:border-zinc-800
               prose-hr:border-zinc-100 dark:prose-hr:border-zinc-900"
-            dangerouslySetInnerHTML={{ __html: contentHtml }} 
+            dangerouslySetInnerHTML={{ __html: contentHtml }}
           />
         </main>
         <Footer vaultRoot={vaultRoot || ""} />
@@ -73,21 +73,21 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
           </header>
 
           <div className="grid gap-16">
-            {result.posts.length > 0 ? (
-              result.posts.map((post) => (
-                <Link key={post.slug} href={`/${post.slug}`} className="group block">
+            {result.pages.length > 0 ? (
+              result.pages.map((page) => (
+                <Link key={page.slug} href={`/${page.slug}`} className="group block">
                   <article className="space-y-4">
                     <div className="flex items-center gap-3 text-xs font-bold tracking-widest uppercase text-zinc-400 dark:text-zinc-500">
-                      <span>{new Date(post.date).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}</span>
+                      <span>{new Date(page.date).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}</span>
                       <span className="w-1 h-1 rounded-full bg-zinc-200 dark:bg-zinc-800" />
-                      <span>{post.slug.split("/").length > 1 ? post.slug.split("/").slice(0, -1).join(" / ") : "Root"}</span>
+                      <span>{page.slug.split("/").length > 1 ? page.slug.split("/").slice(0, -1).join(" / ") : "Root"}</span>
                     </div>
                     <h2 className="text-3xl font-semibold text-zinc-800 dark:text-zinc-200 group-hover:text-zinc-500 dark:group-hover:text-zinc-400 transition-colors tracking-tight">
-                      {post.title}
+                      {page.title}
                     </h2>
-                    {post.excerpt && (
+                    {page.excerpt && (
                       <p className="text-lg text-zinc-500 dark:text-zinc-400 leading-relaxed line-clamp-3">
-                        {post.excerpt}
+                        {page.excerpt}
                       </p>
                     )}
                     <div className="pt-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 group-hover:translate-x-1 transition-transform inline-flex items-center gap-2">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,7 +5,7 @@
 /**
  * The reserved slug for directory indexes and the site home page.
  */
-export const INDEX_SLUG = 'index';
+export const INDEX_SLUG = 'page';
 
 /**
  * The filename for the generated post index of a vault.

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -3,7 +3,7 @@ import { getFileFromS3 } from "./s3";
 import { env } from "./env";
 import { INDEX_SLUG, INDEX_JSON } from "./constants";
 
-export const PostMetadataSchema = z.object({
+export const PageMetadataSchema = z.object({
   title: z.string(),
   slug: z.string(),
   date: z.string(),
@@ -12,16 +12,16 @@ export const PostMetadataSchema = z.object({
 
 export const VaultIndexSchema = z.object({
   version: z.number(),
-  posts: z.array(PostMetadataSchema),
+  pages: z.array(PageMetadataSchema),
   publicFiles: z.array(z.string()),
 });
 
-export type PostMetadata = z.infer<typeof PostMetadataSchema>;
+export type PageMetadata = z.infer<typeof PageMetadataSchema>;
 export type VaultIndex = z.infer<typeof VaultIndexSchema>;
 
 export type VaultContent = 
   | { type: "markdown"; content: string; matchedSlug: string }
-  | { type: "collection"; posts: PostMetadata[]; requestedSlug: string }
+  | { type: "collection"; pages: PageMetadata[]; requestedSlug: string }
   | { type: "asset"; filePath: string };
 
 let cachedIndex: { data: VaultIndex | null; timestamp: number } | null = null;
@@ -79,12 +79,12 @@ export async function resolveVaultRequest(slugArray?: string[]): Promise<VaultCo
   // 1. Fetch index.json for validation and collection filtering
   const index = await getVaultIndex();
   if (!index) return null;
-  const allPosts = index.posts;
+  const allPages = index.pages;
 
   // 2. Routing Priority Logic
   
   // 2a. Direct file match (e.g., /about -> content/about.md)
-  if (allPosts.some((p) => p.slug === requestedSlug)) {
+  if (allPages.some((p) => p.slug === requestedSlug)) {
     const markdown = await getFileFromS3(bucketName, `${vaultRoot}/content/${requestedSlug}.md`);
     return { type: "markdown", content: markdown, matchedSlug: requestedSlug };
   }
@@ -93,7 +93,7 @@ export async function resolveVaultRequest(slugArray?: string[]): Promise<VaultCo
   const indexSlug = `${requestedSlug === INDEX_SLUG ? "" : requestedSlug + "/"}${INDEX_SLUG}`;
   // Special case: if requestedSlug is 'page', indexSlug is 'page'. We already checked that in 2a.
   // But for subfolders, e.g., 'blog', indexSlug is 'blog/page'.
-  if (requestedSlug !== INDEX_SLUG && allPosts.some((p) => p.slug === indexSlug)) {
+  if (requestedSlug !== INDEX_SLUG && allPages.some((p) => p.slug === indexSlug)) {
     const markdown = await getFileFromS3(bucketName, `${vaultRoot}/content/${indexSlug}.md`);
     return { type: "markdown", content: markdown, matchedSlug: indexSlug };
   }
@@ -105,10 +105,10 @@ export async function resolveVaultRequest(slugArray?: string[]): Promise<VaultCo
 
   // 2d. Collection View (list of children in a folder)
   const dirPrefix = requestedSlug === INDEX_SLUG ? "" : `${requestedSlug}/`;
-  const hasChildren = allPosts.some((p) => p.slug.startsWith(dirPrefix));
+  const hasChildren = allPages.some((p) => p.slug.startsWith(dirPrefix));
 
   if (requestedSlug === INDEX_SLUG || hasChildren) {
-    const collectionPosts = allPosts.filter((p) => {
+    const collectionPages = allPages.filter((p) => {
       if (dirPrefix === "") {
         // Root level: show all top-level files (excluding index itself)
         return !p.slug.includes("/") && p.slug !== INDEX_SLUG;
@@ -120,7 +120,7 @@ export async function resolveVaultRequest(slugArray?: string[]): Promise<VaultCo
       return !relativeSlug.includes("/") && p.slug !== INDEX_SLUG && p.slug !== indexSlug;
     });
 
-    return { type: "collection", posts: collectionPosts, requestedSlug };
+    return { type: "collection", pages: collectionPages, requestedSlug };
   }
 
   return null;

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -83,18 +83,18 @@ export async function resolveVaultRequest(slugArray?: string[]): Promise<VaultCo
 
   // 2. Routing Priority Logic
   
-  // 2a. Direct file match (e.g., /about -> about.md)
+  // 2a. Direct file match (e.g., /about -> content/about.md)
   if (allPosts.some((p) => p.slug === requestedSlug)) {
-    const markdown = await getFileFromS3(bucketName, `${vaultRoot}/${requestedSlug}.md`);
+    const markdown = await getFileFromS3(bucketName, `${vaultRoot}/content/${requestedSlug}.md`);
     return { type: "markdown", content: markdown, matchedSlug: requestedSlug };
   }
 
-  // 2b. Directory index match (e.g., /folder -> folder/index.md)
+  // 2b. Directory index match (e.g., /folder -> content/folder/page.md)
   const indexSlug = `${requestedSlug === INDEX_SLUG ? "" : requestedSlug + "/"}${INDEX_SLUG}`;
-  // Special case: if requestedSlug is 'index', indexSlug is 'index'. We already checked that in 2a.
-  // But for subfolders, e.g., 'blog', indexSlug is 'blog/index'.
+  // Special case: if requestedSlug is 'page', indexSlug is 'page'. We already checked that in 2a.
+  // But for subfolders, e.g., 'blog', indexSlug is 'blog/page'.
   if (requestedSlug !== INDEX_SLUG && allPosts.some((p) => p.slug === indexSlug)) {
-    const markdown = await getFileFromS3(bucketName, `${vaultRoot}/${indexSlug}.md`);
+    const markdown = await getFileFromS3(bucketName, `${vaultRoot}/content/${indexSlug}.md`);
     return { type: "markdown", content: markdown, matchedSlug: indexSlug };
   }
 


### PR DESCRIPTION
This PR refactors the content storage and routing logic to align with modern conventions and improve organization.

Key changes:
- **Mandatory `content/` directory**: Vault content must now reside in a `content/` subdirectory.
- **Naming Migration**: Renamed the default index file from `index.md` to `page.md` (and `INDEX_SLUG` from `index` to `page`).
- **Terminology Refactor**: Replaced `Post` with `Page` throughout the codebase (types, schemas, and UI components) for better conceptual alignment.
- **Improved Validation**: The `sync` script now verifies the existence of the `content/` directory and warns if the root `page.md` is missing.
- **Static Asset Handling**: The `sync` script now correctly handles the `public/` directory within the vault.
- **UI Updates**: Updated `DynamicPage` to support the new `pages` data structure.