### PR TITLE
Add sitemap generation and refactor proxying

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -928,7 +928,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1196,6 +1195,28 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3596,6 +3617,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -4850,7 +4894,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4861,7 +4904,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4927,7 +4969,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -7721,7 +7762,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8219,7 +8259,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9200,7 +9239,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9386,7 +9424,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13281,7 +13318,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13291,7 +13327,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14357,8 +14392,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -14511,7 +14545,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14769,7 +14802,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15599,7 +15631,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16041,7 +16072,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { getRegistry } from '../src/lib/registry';
 import { env } from '../src/lib/env';
-import { INDEX_JSON, ROOT_JSON } from '../src/lib/constants';
+import { INDEX_JSON, ROOT_JSON, SITEMAP_XML, SITEMAP_PAGES_XML } from '../src/lib/constants';
 import { PageMetadata, VaultDirectoryIndex, VaultRootIndex } from '../src/lib/vault';
 import { hasFlag, getFlagValue } from '../src/lib/cli';
 
@@ -44,6 +44,50 @@ function parseSafeDate(dateInput: any, fallback: Date, label: string, filePath: 
   return date.toISOString();
 }
 
+function escapeXml(unsafe: string): string {
+  return unsafe.replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '&': return '&amp;';
+      case '\'': return '&apos;';
+      case '"': return '&quot;';
+    }
+    return c;
+  });
+}
+
+function generateSitemapXml(domain: string, pages: PageMetadata[], baseSlug: string = ''): string {
+  const baseUrl = `https://${domain}`;
+  const entries = pages.map(page => {
+    const slug = baseSlug ? `${baseSlug}/${page.slug}` : page.slug;
+    const url = `${baseUrl}/${slug === 'page' ? '' : slug}`;
+    return `  <url>
+    <loc>${escapeXml(url)}</loc>
+    <lastmod>${page.updatedAt || page.date}</lastmod>
+  </url>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</urlset>`;
+}
+
+function generateSitemapIndexXml(domain: string, sitemaps: string[]): string {
+  const baseUrl = `https://${domain}`;
+  const entries = sitemaps.map(path => {
+    const url = `${baseUrl}/${path}`;
+    return `  <sitemap>
+    <loc>${escapeXml(url)}</loc>
+  </sitemap>`;
+  }).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</sitemapindex>`;
+}
 
 async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<string[]> {
   const files: string[] = [];
@@ -70,20 +114,22 @@ async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<stri
   return files;
 }
 
-async function scanAndGenerate(dir: string, baseDir: string, dryRun: boolean): Promise<{ index: VaultDirectoryIndex; allDirs: string[] }> {
+async function scanAndGenerate(dir: string, baseDir: string, domain: string, dryRun: boolean): Promise<{ index: VaultDirectoryIndex; allDirs: string[]; sitemapDirs: string[] }> {
   const entries = await readdir(dir, { withFileTypes: true });
   const pages: PageMetadata[] = [];
   let allDirs: string[] = [];
+  let sitemapDirs: string[] = [];
 
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
 
     if (entry.isDirectory()) {
       if (entry.name !== '.git' && entry.name !== 'node_modules') {
-        const result = await scanAndGenerate(fullPath, baseDir, dryRun);
+        const result = await scanAndGenerate(fullPath, baseDir, domain, dryRun);
 
         const relDir = relative(baseDir, fullPath).replace(/\\/g, '/');
         allDirs.push(relDir, ...result.allDirs);
+        sitemapDirs.push(...result.sitemapDirs);
       }
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
       const fileContent = await readFile(fullPath, 'utf-8');
@@ -131,17 +177,28 @@ async function scanAndGenerate(dir: string, baseDir: string, dryRun: boolean): P
   };
 
   const indexPath = join(dir, INDEX_JSON);
-  const relDirName = relative(baseDir, dir) || 'root';
+  const sitemapPath = join(dir, SITEMAP_XML);
+  const relDir = relative(baseDir, dir).replace(/\\/g, '/');
+  const relDirName = relDir || 'root';
 
   if (!dryRun) {
     await writeFile(indexPath, JSON.stringify(indexData, null, 2));
     console.log(`✨ Generated index for "${relDirName}"`);
+
+    if (pages.length > 0) {
+      const sitemapXml = generateSitemapXml(domain, pages, relDir);
+      await writeFile(sitemapPath, sitemapXml);
+      console.log(`✨ Generated sitemap.xml for "${relDirName}"`);
+      if (relDir) {
+        sitemapDirs.push(relDir);
+      }
+    }
   }
 
-  return { index: indexData, allDirs };
+  return { index: indexData, allDirs, sitemapDirs };
 }
 
-async function generateIndices(vaultPath: string, dryRun: boolean = false) {
+async function generateIndices(vaultPath: string, domain: string, dryRun: boolean = false) {
   const publicBaseDir = join(vaultPath, 'public');
   const publicFiles = await exists(publicBaseDir) ? await scanPublicFiles(publicBaseDir) : [];
 
@@ -151,9 +208,9 @@ async function generateIndices(vaultPath: string, dryRun: boolean = false) {
     process.exit(1);
   }
 
-  // 1. Recursive generation of index.json for each level in content/
+  // 1. Recursive generation of index.json and sitemap.xml for each level in content/
   console.log(`\n🔍 Recursively scanning "content" directory in ${contentDir}...`);
-  const { index: rootContentIndex, allDirs } = await scanAndGenerate(contentDir, contentDir, dryRun);
+  const { index: rootContentIndex, allDirs, sitemapDirs } = await scanAndGenerate(contentDir, contentDir, domain, dryRun);
 
   // 2. Generate root.json at vault root pointing to top-level content
   const rootPath = join(vaultPath, ROOT_JSON);
@@ -163,11 +220,28 @@ async function generateIndices(vaultPath: string, dryRun: boolean = false) {
     publicFiles,
   };
 
+  // 3. Generate sitemaps at vault root
+  const sitemapIndexPath = join(vaultPath, SITEMAP_XML);
+  const sitemapPagesPath = join(vaultPath, SITEMAP_PAGES_XML);
+
   if (dryRun) {
     console.log(`[DRY RUN] Would generate master root index at: ${rootPath}`);
+    console.log(`[DRY RUN] Would generate root sitemap index at: ${sitemapIndexPath}`);
+    console.log(`[DRY RUN] Would generate root pages sitemap at: ${sitemapPagesPath}`);
   } else {
     await writeFile(rootPath, JSON.stringify(vaultRootIndex, null, 2));
     console.log(`✨ Generated master root index with ${allDirs.length} directories at: ${rootPath}`);
+
+    // root sitemap_pages.xml for root pages
+    const rootSitemapPagesXml = generateSitemapXml(domain, rootContentIndex.pages);
+    await writeFile(sitemapPagesPath, rootSitemapPagesXml);
+    console.log(`✨ Generated root pages sitemap at: ${sitemapPagesPath}`);
+
+    // root sitemap.xml as an index of all other sitemaps
+    const subSitemaps = sitemapDirs.map(dir => `${dir}/${SITEMAP_XML}`);
+    const sitemapIndexXml = generateSitemapIndexXml(domain, [SITEMAP_PAGES_XML, ...subSitemaps]);
+    await writeFile(sitemapIndexPath, sitemapIndexXml);
+    console.log(`✨ Generated root sitemap index at: ${sitemapIndexPath}`);
   }
 }
 
@@ -209,7 +283,7 @@ async function main() {
   }
 
   // Generate index files at every level and root.json at the vault root before syncing
-  await generateIndices(site.vaultPath, isDryRun);
+  await generateIndices(site.vaultPath, site.domain, isDryRun);
 
   const endpoint = registry.endpoint || env.S3_ENDPOINT;
   const accessKeyId = registry.accessKeyId || env.S3_ACCESS_KEY_ID;

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -57,11 +57,6 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
     notFound();
   }
 
-  // 0. Handle public assets (redirect to API route)
-  if (result.type === "asset") {
-    redirect(`/api/vault-public/${result.filePath}`);
-  }
-
   // 1. Render matched Markdown file
   if (result.type === "markdown") {
     const { content: markdownBody } = matter(result.content);

--- a/src/app/api/sitemap/[[...path]]/route.ts
+++ b/src/app/api/sitemap/[[...path]]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getRegistry } from "@/lib/registry";
+import { env } from "@/lib/env";
+
+let s3Client: S3Client | null = null;
+
+async function getS3Client() {
+  if (s3Client) return s3Client;
+
+  const registry = await getRegistry();
+  const endpoint = registry.endpoint || env.S3_ENDPOINT;
+  const accessKeyId = registry.accessKeyId || env.S3_ACCESS_KEY_ID;
+  const secretAccessKey = registry.secretAccessKey || env.S3_SECRET_ACCESS_KEY;
+
+  if (!endpoint || !accessKeyId || !secretAccessKey) {
+    throw new Error("Missing S3 credentials.");
+  }
+
+  s3Client = new S3Client({
+    endpoint,
+    region: "auto",
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
+    forcePathStyle: true,
+  });
+
+  return s3Client;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ path?: string[] }> }
+) {
+  const { path: pathArray } = await params;
+  const filePath = pathArray?.join("/") || "sitemap.xml";
+  const vaultRoot = env.VAULT_ROOT;
+  const bucketName = env.S3_BUCKET;
+
+  if (!vaultRoot || !bucketName) {
+    return new NextResponse("Site configuration missing", { status: 500 });
+  }
+
+  try {
+    const client = await getS3Client();
+    const key = `${vaultRoot}/${filePath}`;
+
+    const command = new GetObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+    });
+
+    const response = await client.send(command);
+
+    if (!response.Body) {
+      return new NextResponse("Not Found", { status: 404 });
+    }
+
+    // Use a custom ReadableStream to return the body
+    const body = response.Body as any;
+
+    return new NextResponse(body.transformToWebStream(), {
+      headers: {
+        "Content-Type": "text/xml",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  } catch (error: any) {
+    console.error(`Error serving sitemap [${filePath}]:`, error.message);
+    return new NextResponse("Not Found", { status: 404 });
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,6 +18,16 @@ export const INDEX_JSON = 'index.json';
 export const ROOT_JSON = 'root.json';
 
 /**
+ * The filename for the sitemap index of a vault.
+ */
+export const SITEMAP_XML = 'sitemap.xml';
+
+/**
+ * The filename for the sitemap containing only pages.
+ */
+export const SITEMAP_PAGES_XML = 'sitemap_pages.xml';
+
+/**
  * The default filename for the registry configuration.
  */
 export const DEFAULT_REGISTRY_FILENAME = 'registry.json';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as default, config } from './proxy';

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { fetchRootIndex } from './lib/vault';
+import { env } from './lib/env';
 
 export async function proxy(request: NextRequest) {
   const url = new URL(request.url);
@@ -14,24 +16,43 @@ export async function proxy(request: NextRequest) {
   }
 
   // 2. Handle fallback for system files like favicon.ico
-  // If the API route redirects back here with ?fallback=true, we skip the vault rewrite.
   if (url.searchParams.get('fallback') === 'true') {
     return NextResponse.next();
   }
 
-  // 3. Check if the path looks like a static file (has an extension)
-  const hasExtension = pathname.includes('.') && !pathname.endsWith('/');
-  if (!hasExtension) {
-    return NextResponse.next();
+  // 3. Handle sitemap.xml and sitemap_pages.xml
+  if (pathname === '/sitemap.xml' || pathname === '/sitemap_pages.xml') {
+    return NextResponse.rewrite(new URL(`/api/sitemap${pathname}`, request.url));
   }
 
-  // 4. Normalize path for matching (remove leading slash)
-  const filePath = pathname.slice(1);
+  // 4. Handle nested sitemap.xml (e.g., /dir/sitemap.xml -> /api/sitemap/content/dir/sitemap.xml)
+  if (pathname.endsWith('/sitemap.xml')) {
+    const dirPath = pathname.slice(1, -'sitemap.xml'.length);
+    return NextResponse.rewrite(new URL(`/api/sitemap/content/${dirPath}sitemap.xml`, request.url));
+  }
 
-  // 5. Blind rewrite to vault-public API route
-  // Local files in /public/ are served by Next.js before middleware (if configured)
-  // or will result in a 404 (or fallback redirect) from the API route if not in S3.
-  return NextResponse.rewrite(new URL(`/api/vault-public/${filePath}`, request.url));
+  // 5. Check if the path looks like a static file (has an extension)
+  const hasExtension = pathname.includes('.') && !pathname.endsWith('/');
+  if (hasExtension) {
+    const filePath = pathname.slice(1);
+    return NextResponse.rewrite(new URL(`/api/vault-public/${filePath}`, request.url));
+  }
+
+  // 6. Check if it's a public file without extension (from root.json)
+  const vaultConfig = {
+    bucketName: env.S3_BUCKET!,
+    vaultRoot: env.VAULT_ROOT!,
+  };
+
+  if (vaultConfig.bucketName && vaultConfig.vaultRoot) {
+    const rootIndex = await fetchRootIndex(vaultConfig);
+    const filePath = pathname.slice(1);
+    if (rootIndex?.publicFiles.includes(filePath)) {
+      return NextResponse.rewrite(new URL(`/api/vault-public/${filePath}`, request.url));
+    }
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
This change adds support for generating a hierarchical sitemap structure during the content synchronization process. It also refactors the way static files and sitemaps are served by using a centralized middleware/proxy approach, which simplifies the main page route handler and improves consistency in how vault assets are matched and proxied to S3.

Fixes #24

---
*PR created automatically by Jules for task [10669915672775290414](https://jules.google.com/task/10669915672775290414) started by @speshiou*