### PR TITLE
refactor: Sitemap Generation ENOENT and Sync orchestrator Logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,5 +14,6 @@ Always run `npm run type-check` after making changes to verify basic syntax erro
 
 # Skills
 Consult the `skills/` directory for specific guides and automation patterns:
-- [Pull Request Creation](skills/pull-request.md)
-- [Registry Migration](skills/registry-migration.md)
+- [Pull Request Creation](skills/pull-request/SKILL.md)
+- [Registry Migration](skills/registry-migration/SKILL.md)
+- [Coding Conventions](skills/coding-conventions/SKILL.md)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Keep your images, PDFs, and other assets organized here.
 - **Zero Configuration**: Just drop a file in `public/assets/logo.png` and it's available at `/assets/logo.png`.
 
 ### Automated SEO & Sitemaps
-Every time you sync, Notopress automatically generates a valid, search-engine-friendly `sitemap.xml`.
+Every time you sync, Notopress automatically generates a valid, search-engine-friendly `sitemap.xml` (if a `domain` is configured).
 - **Discovery**: Helps search engines find and index all your content instantly.
 - **Scalability**: For large sites, Notopress automatically creates a sitemap index and nested sub-sitemaps to keep things organized and within search engine limits.
 
@@ -68,7 +68,7 @@ The registry manages global defaults and site-specific overrides.
 **Site-Specific Settings**
 | Property | Type | Description |
 | :--- | :--- | :--- |
-| `domain` | `string` | Your site's domain. Used to generate absolute URLs for the sitemap. |
+| `domain` | `string` | (Optional) Your site's domain. Used to generate absolute URLs for the sitemap. If omitted, sitemap generation will be skipped. |
 | `siteId` | `string` | A unique ID for the site, used as its root folder in S3. |
 | `vaultPath` | `string` | Absolute path to your local markdown vault. |
 | `bucketName` | `string` | (Optional) The S3 bucket name. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -928,7 +928,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1196,6 +1195,28 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3596,6 +3617,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -4850,7 +4894,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4861,7 +4904,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4927,7 +4969,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -7721,7 +7762,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8219,7 +8259,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9200,7 +9239,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9386,7 +9424,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13281,7 +13318,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13291,7 +13327,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14357,8 +14392,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -14511,7 +14545,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14769,7 +14802,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15599,7 +15631,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16041,7 +16072,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -1,8 +1,9 @@
 import { select } from '@inquirer/prompts';
 import matter from 'gray-matter';
+import { z } from 'zod';
 import { readFile, writeFile, readdir, stat, unlink, access, mkdir } from 'fs/promises';
 import { constants } from 'fs';
-import { spawn } from 'child_process';
+import { spawn, SpawnOptions } from 'child_process';
 import { join, relative } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
@@ -22,7 +23,7 @@ async function exists(path: string) {
   }
 }
 
-async function execAsync({ command, options }: { command: string; options: any }): Promise<void> {
+async function execAsync({ command, options }: { command: string; options: SpawnOptions }): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, { ...options, shell: true });
     child.on('close', (code) => {
@@ -33,22 +34,34 @@ async function execAsync({ command, options }: { command: string; options: any }
   });
 }
 
+const DateInputSchema = z.union([z.string(), z.number(), z.date()]);
+
 function parseSafeDate({
   dateInput,
   fallback,
   label,
   filePath,
 }: {
-  dateInput: any;
+  dateInput: unknown;
   fallback: Date;
   label: string;
   filePath: string;
 }): string {
   if (!dateInput) return fallback.toISOString();
 
-  const date = new Date(dateInput);
+  const result = DateInputSchema.safeParse(dateInput);
+  if (!result.success) {
+    console.warn(
+      `⚠️  Warning: Invalid ${label} type for "${dateInput}" in ${filePath}. Falling back to file modification time.`
+    );
+    return fallback.toISOString();
+  }
+
+  const date = new Date(result.data);
   if (isNaN(date.getTime())) {
-    console.warn(`⚠️  Warning: Invalid ${label} "${dateInput}" in ${filePath}. Falling back to file modification time.`);
+    console.warn(
+      `⚠️  Warning: Invalid ${label} value "${dateInput}" in ${filePath}. Falling back to file modification time.`
+    );
     return fallback.toISOString();
   }
 
@@ -571,9 +584,10 @@ async function main() {
       await uploadRegistry({ site, registry });
       console.log('\n✅ Sync and registry upload successfully completed!');
     }
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error(`\n⨯ ${isDryRun ? 'Dry run' : 'Sync process'} failed.`);
-    console.error(err.message);
+    console.error(message);
     process.exit(1);
   }
 }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -233,47 +233,70 @@ async function generateIndices(vaultPath: string, domain: string, dryRun: boolea
     subSitemaps
   );
 
-  // Generate sitemap_pages.xml for root level pages
-  const rootPages = rootContentIndex.pages;
-  if (rootPages.length > 0) {
-    const sitemapUrls = rootPages.map((p) => {
-      const path = p.slug === INDEX_SLUG ? '' : p.slug;
-      return {
-        loc: `https://${domain}/${path}`,
-        lastmod: p.updatedAt || p.date,
-      };
-    });
-    const sitemapContent = generateSitemapXml(sitemapUrls);
-    const sitemapPath = join(vaultPath, 'public', 'sitemap_pages.xml');
-    if (!dryRun) {
-      await writeFile(sitemapPath, sitemapContent);
-      console.log(`✨ Generated root pages sitemap at public/sitemap_pages.xml`);
-    } else {
-      console.log(`[DRY RUN] Would generate root pages sitemap at public/sitemap_pages.xml`);
-    }
-  }
-
-  // Generate main sitemap.xml as a sitemap index
-  const sitemaps = [];
-  if (rootPages.length > 0) {
-    sitemaps.push({ loc: `https://${domain}/sitemap_pages.xml` });
-  }
-  for (const subSitemap of subSitemaps) {
-    sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
-  }
-
-  if (sitemaps.length > 0) {
-    const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
-    const sitemapIndexPath = join(vaultPath, 'public', 'sitemap.xml');
-    if (!dryRun) {
-      await writeFile(sitemapIndexPath, sitemapIndexContent);
-      console.log(`✨ Generated master sitemap index at public/sitemap.xml`);
-    } else {
-      console.log(`[DRY RUN] Would generate master sitemap index at public/sitemap.xml`);
-    }
-  }
-
   const publicBaseDir = join(vaultPath, 'public');
+  if (!dryRun) {
+    await mkdir(publicBaseDir, { recursive: true });
+  }
+
+  // Generate sitemaps
+  const rootPages = rootContentIndex.pages;
+  if (subSitemaps.length === 0) {
+    // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
+    if (rootPages.length > 0) {
+      const sitemapUrls = rootPages.map((p) => {
+        const path = p.slug === INDEX_SLUG ? '' : p.slug;
+        return {
+          loc: `https://${domain}/${path}`,
+          lastmod: p.updatedAt || p.date,
+        };
+      });
+      const sitemapContent = generateSitemapXml(sitemapUrls);
+      const sitemapPath = join(publicBaseDir, 'sitemap.xml');
+      if (!dryRun) {
+        await writeFile(sitemapPath, sitemapContent);
+        console.log(`✨ Generated sitemap at public/sitemap.xml`);
+      } else {
+        console.log(`[DRY RUN] Would generate sitemap at public/sitemap.xml`);
+      }
+    }
+  } else {
+    // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
+    const sitemaps = [];
+
+    if (rootPages.length > 0) {
+      const sitemapUrls = rootPages.map((p) => {
+        const path = p.slug === INDEX_SLUG ? '' : p.slug;
+        return {
+          loc: `https://${domain}/${path}`,
+          lastmod: p.updatedAt || p.date,
+        };
+      });
+      const sitemapContent = generateSitemapXml(sitemapUrls);
+      const sitemapPath = join(publicBaseDir, 'sitemap_pages.xml');
+      if (!dryRun) {
+        await writeFile(sitemapPath, sitemapContent);
+        console.log(`✨ Generated root pages sitemap at public/sitemap_pages.xml`);
+      } else {
+        console.log(`[DRY RUN] Would generate root pages sitemap at public/sitemap_pages.xml`);
+      }
+      sitemaps.push({ loc: `https://${domain}/sitemap_pages.xml` });
+    }
+
+    for (const subSitemap of subSitemaps) {
+      sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
+    }
+
+    if (sitemaps.length > 0) {
+      const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
+      const sitemapIndexPath = join(publicBaseDir, 'sitemap.xml');
+      if (!dryRun) {
+        await writeFile(sitemapIndexPath, sitemapIndexContent);
+        console.log(`✨ Generated master sitemap index at public/sitemap.xml`);
+      } else {
+        console.log(`[DRY RUN] Would generate master sitemap index at public/sitemap.xml`);
+      }
+    }
+  }
   const publicFiles = (await exists(publicBaseDir)) ? await scanPublicFiles(publicBaseDir) : [];
 
   // 2. Generate root.json at vault root pointing to top-level content

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -22,7 +22,7 @@ async function exists(path: string) {
   }
 }
 
-async function execAsync(command: string, options: any): Promise<void> {
+async function execAsync({ command, options }: { command: string; options: any }): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, { ...options, shell: true });
     child.on('close', (code) => {
@@ -33,7 +33,17 @@ async function execAsync(command: string, options: any): Promise<void> {
   });
 }
 
-function parseSafeDate(dateInput: any, fallback: Date, label: string, filePath: string): string {
+function parseSafeDate({
+  dateInput,
+  fallback,
+  label,
+  filePath,
+}: {
+  dateInput: any;
+  fallback: Date;
+  label: string;
+  filePath: string;
+}): string {
   if (!dateInput) return fallback.toISOString();
 
   const date = new Date(dateInput);
@@ -86,7 +96,15 @@ ${sitemapTags}
 </sitemapindex>`;
 }
 
-function mapPagesToSitemapUrls(pages: PageMetadata[], domain: string, relDir: string = '') {
+function mapPagesToSitemapUrls({
+  pages,
+  domain,
+  relDir = '',
+}: {
+  pages: PageMetadata[];
+  domain: string;
+  relDir?: string;
+}) {
   return pages.map((p) => {
     const urlPath = p.slug === INDEX_SLUG ? relDir : relDir ? `${relDir}/${p.slug}` : p.slug;
     return {
@@ -96,13 +114,19 @@ function mapPagesToSitemapUrls(pages: PageMetadata[], domain: string, relDir: st
   });
 }
 
-async function writeSitemapFile(
-  fullPath: string,
-  relPath: string,
-  content: string,
-  dryRun: boolean,
-  label: string
-) {
+async function writeSitemapFile({
+  fullPath,
+  relPath,
+  content,
+  dryRun,
+  label,
+}: {
+  fullPath: string;
+  relPath: string;
+  content: string;
+  dryRun: boolean;
+  label: string;
+}) {
   if (!dryRun) {
     const dir = join(fullPath, '..');
     await mkdir(dir, { recursive: true });
@@ -113,7 +137,7 @@ async function writeSitemapFile(
   }
 }
 
-async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<string[]> {
+async function scanPublicFiles({ dir, baseDir = dir }: { dir: string; baseDir?: string }): Promise<string[]> {
   const files: string[] = [];
 
   async function walk(currentDir: string) {
@@ -138,34 +162,50 @@ async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<stri
   return files;
 }
 
-async function generateAllSitemaps(
-  domain: string,
-  allIndices: Map<string, VaultDirectoryIndex>,
-  vaultPath: string,
-  dryRun: boolean
-): Promise<string[]> {
+async function generateAllSitemaps({
+  domain,
+  allIndices,
+  vaultPath,
+  dryRun,
+}: {
+  domain: string;
+  allIndices: Map<string, VaultDirectoryIndex>;
+  vaultPath: string;
+  dryRun: boolean;
+}): Promise<string[]> {
   const subSitemaps: string[] = [];
   for (const [relDir, indexData] of allIndices.entries()) {
     if (relDir === '') continue; // Skip root, handled separately
     if (indexData.pages.length === 0) continue;
 
-    const sitemapUrls = mapPagesToSitemapUrls(indexData.pages, domain, relDir);
+    const sitemapUrls = mapPagesToSitemapUrls({ pages: indexData.pages, domain, relDir });
     const sitemapContent = generateSitemapXml(sitemapUrls);
     const sitemapPath = join(vaultPath, 'public', relDir, SITEMAP_XML);
     const relSitemapPath = `public/${relDir}/${SITEMAP_XML}`;
 
-    await writeSitemapFile(sitemapPath, relSitemapPath, sitemapContent, dryRun, `sitemap for "${relDir}"`);
+    await writeSitemapFile({
+      fullPath: sitemapPath,
+      relPath: relSitemapPath,
+      content: sitemapContent,
+      dryRun,
+      label: `sitemap for "${relDir}"`,
+    });
     subSitemaps.push(`${relDir}/${SITEMAP_XML}`);
   }
   return subSitemaps;
 }
 
-async function scanAndGenerate(
-  dir: string,
-  baseDir: string,
-  dryRun: boolean,
-  allIndices: Map<string, VaultDirectoryIndex>
-): Promise<{ index: VaultDirectoryIndex; allDirs: string[] }> {
+async function scanAndGenerate({
+  dir,
+  baseDir,
+  dryRun,
+  allIndices,
+}: {
+  dir: string;
+  baseDir: string;
+  dryRun: boolean;
+  allIndices: Map<string, VaultDirectoryIndex>;
+}): Promise<{ index: VaultDirectoryIndex; allDirs: string[] }> {
   const entries = await readdir(dir, { withFileTypes: true });
   const pages: PageMetadata[] = [];
   let allDirs: string[] = [];
@@ -177,7 +217,7 @@ async function scanAndGenerate(
 
     if (entry.isDirectory()) {
       if (entry.name !== '.git' && entry.name !== 'node_modules') {
-        const result = await scanAndGenerate(fullPath, baseDir, dryRun, allIndices);
+        const result = await scanAndGenerate({ dir: fullPath, baseDir, dryRun, allIndices });
 
         const childRelDir = relative(baseDir, fullPath).replace(/\\/g, '/');
         allDirs.push(childRelDir, ...result.allDirs);
@@ -193,20 +233,29 @@ async function scanAndGenerate(
       }
 
       const titleMatch = content.match(/^#\s+(.+)$/m);
-      const title = (typeof data.title === 'string' && data.title.trim() !== '' ? data.title : (titleMatch ? titleMatch[1].trim() : entry.name));
+      const title =
+        typeof data.title === 'string' && data.title.trim() !== ''
+          ? data.title
+          : titleMatch
+          ? titleMatch[1].trim()
+          : entry.name;
 
       const relPath = relative(dir, fullPath);
       const slug = relPath.replace(/\.md$/, '').replace(/\\/g, '/');
 
-      const date = parseSafeDate(data.date, fileStats.mtime, 'date', relPath);
+      const date = parseSafeDate({ dateInput: data.date, fallback: fileStats.mtime, label: 'date', filePath: relPath });
       const manualUpdate = data.updated || data.lastmod;
-      const updatedAt = parseSafeDate(manualUpdate, fileStats.mtime, 'updated', relPath);
+      const updatedAt = parseSafeDate({
+        dateInput: manualUpdate,
+        fallback: fileStats.mtime,
+        label: 'updated',
+        filePath: relPath,
+      });
 
       const firstParagraph = content
         .split('\n')
-        .map(line => line.trim())
-        .filter(line => line && !line.startsWith('#') && !line.startsWith('>'))
-      [0];
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith('#') && !line.startsWith('>'))[0];
 
       let excerpt = '';
       if (firstParagraph) {
@@ -269,7 +318,7 @@ async function selectSite(registry: Registry): Promise<Site> {
   return site;
 }
 
-async function syncSite(site: Site, registry: Registry, isDryRun: boolean) {
+async function syncSite({ site, registry, isDryRun }: { site: Site; registry: Registry; isDryRun: boolean }) {
   const endpoint = site.endpoint || registry.endpoint || env.S3_ENDPOINT;
   const accessKeyId = registry.accessKeyId || env.S3_ACCESS_KEY_ID;
   const secretAccessKey = registry.secretAccessKey || env.S3_SECRET_ACCESS_KEY;
@@ -306,17 +355,20 @@ async function syncSite(site: Site, registry: Registry, isDryRun: boolean) {
   console.log(`Executing:\n> ${syncCommand}\n`);
 
   // stdio: 'inherit' passes the aws-cli output directly to our terminal
-  await execAsync(syncCommand, {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      AWS_ACCESS_KEY_ID: accessKeyId,
-      AWS_SECRET_ACCESS_KEY: secretAccessKey,
+  await execAsync({
+    command: syncCommand,
+    options: {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: accessKeyId,
+        AWS_SECRET_ACCESS_KEY: secretAccessKey,
+      },
     },
   });
 }
 
-async function uploadRegistry(site: Site, registry: Registry) {
+async function uploadRegistry({ site, registry }: { site: Site; registry: Registry }) {
   const endpoint = site.endpoint || registry.endpoint || env.S3_ENDPOINT;
   const accessKeyId = registry.accessKeyId || env.S3_ACCESS_KEY_ID;
   const secretAccessKey = registry.secretAccessKey || env.S3_SECRET_ACCESS_KEY;
@@ -349,12 +401,15 @@ async function uploadRegistry(site: Site, registry: Registry) {
       `--endpoint-url "${endpoint}"`,
     ].join(' ');
 
-    await execAsync(uploadRegistryCommand, {
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        AWS_ACCESS_KEY_ID: accessKeyId,
-        AWS_SECRET_ACCESS_KEY: secretAccessKey,
+    await execAsync({
+      command: uploadRegistryCommand,
+      options: {
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          AWS_ACCESS_KEY_ID: accessKeyId,
+          AWS_SECRET_ACCESS_KEY: secretAccessKey,
+        },
       },
     });
   } finally {
@@ -364,7 +419,13 @@ async function uploadRegistry(site: Site, registry: Registry) {
   }
 }
 
-async function generateIndices(vaultPath: string, dryRun: boolean = false) {
+async function generateIndices({
+  vaultPath,
+  dryRun = false,
+}: {
+  vaultPath: string;
+  dryRun?: boolean;
+}): Promise<{ rootContentIndex: VaultDirectoryIndex; allIndices: Map<string, VaultDirectoryIndex> }> {
   const contentDir = join(vaultPath, 'content');
   if (!(await exists(contentDir))) {
     console.error(`⨯ Error: The required "content" directory is missing in the vault: ${vaultPath}`);
@@ -374,19 +435,19 @@ async function generateIndices(vaultPath: string, dryRun: boolean = false) {
   // 1. Recursive generation of index.json for each level in content/
   console.log(`\n🔍 Recursively scanning "content" directory in ${contentDir}...`);
   const allIndices = new Map<string, VaultDirectoryIndex>();
-  const { index: rootContentIndex, allDirs } = await scanAndGenerate(
-    contentDir,
-    contentDir,
+  const { index: rootContentIndex, allDirs } = await scanAndGenerate({
+    dir: contentDir,
+    baseDir: contentDir,
     dryRun,
-    allIndices
-  );
+    allIndices,
+  });
 
   const publicBaseDir = join(vaultPath, 'public');
   if (!dryRun) {
     await mkdir(publicBaseDir, { recursive: true });
   }
 
-  const publicFiles = (await exists(publicBaseDir)) ? await scanPublicFiles(publicBaseDir) : [];
+  const publicFiles = (await exists(publicBaseDir)) ? await scanPublicFiles({ dir: publicBaseDir }) : [];
 
   // 2. Generate root.json at vault root pointing to top-level content
   const rootPath = join(vaultPath, ROOT_JSON);
@@ -406,29 +467,41 @@ async function generateIndices(vaultPath: string, dryRun: boolean = false) {
   return { rootContentIndex, allIndices };
 }
 
-async function generateSitemaps(
-  vaultPath: string,
-  domain: string | undefined,
-  rootContentIndex: VaultDirectoryIndex,
-  allIndices: Map<string, VaultDirectoryIndex>,
-  dryRun: boolean
-) {
+async function generateSitemaps({
+  vaultPath,
+  domain,
+  rootContentIndex,
+  allIndices,
+  dryRun,
+}: {
+  vaultPath: string;
+  domain: string | undefined;
+  rootContentIndex: VaultDirectoryIndex;
+  allIndices: Map<string, VaultDirectoryIndex>;
+  dryRun: boolean;
+}) {
   if (!domain) {
     console.log('ℹ️  Skipping sitemap generation because "domain" is not configured in registry.json');
     return;
   }
 
   const publicBaseDir = join(vaultPath, 'public');
-  const subSitemaps = await generateAllSitemaps(domain, allIndices, vaultPath, dryRun);
+  const subSitemaps = await generateAllSitemaps({ domain, allIndices, vaultPath, dryRun });
   const rootPages = rootContentIndex.pages;
-  const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls(rootPages, domain) : [];
+  const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls({ pages: rootPages, domain }) : [];
 
   if (subSitemaps.length === 0) {
     // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
     if (sitemapUrls.length > 0) {
       const sitemapContent = generateSitemapXml(sitemapUrls);
       const sitemapPath = join(publicBaseDir, SITEMAP_XML);
-      await writeSitemapFile(sitemapPath, `public/${SITEMAP_XML}`, sitemapContent, dryRun, 'sitemap');
+      await writeSitemapFile({
+        fullPath: sitemapPath,
+        relPath: `public/${SITEMAP_XML}`,
+        content: sitemapContent,
+        dryRun,
+        label: 'sitemap',
+      });
     }
   } else {
     // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
@@ -437,7 +510,13 @@ async function generateSitemaps(
     if (sitemapUrls.length > 0) {
       const sitemapContent = generateSitemapXml(sitemapUrls);
       const sitemapPath = join(publicBaseDir, SITEMAP_PAGES_XML);
-      await writeSitemapFile(sitemapPath, `public/${SITEMAP_PAGES_XML}`, sitemapContent, dryRun, 'root pages sitemap');
+      await writeSitemapFile({
+        fullPath: sitemapPath,
+        relPath: `public/${SITEMAP_PAGES_XML}`,
+        content: sitemapContent,
+        dryRun,
+        label: 'root pages sitemap',
+      });
       sitemaps.push({ loc: `https://${domain}/${SITEMAP_PAGES_XML}` });
     }
 
@@ -448,7 +527,13 @@ async function generateSitemaps(
     if (sitemaps.length > 0) {
       const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
       const sitemapIndexPath = join(publicBaseDir, SITEMAP_XML);
-      await writeSitemapFile(sitemapIndexPath, `public/${SITEMAP_XML}`, sitemapIndexContent, dryRun, 'master sitemap index');
+      await writeSitemapFile({
+        fullPath: sitemapIndexPath,
+        relPath: `public/${SITEMAP_XML}`,
+        content: sitemapIndexContent,
+        dryRun,
+        label: 'master sitemap index',
+      });
     }
   }
 }
@@ -467,17 +552,23 @@ async function main() {
     const site = await selectSite(registry);
 
     // Generate index files at every level and root.json at the vault root
-    const { rootContentIndex, allIndices } = await generateIndices(site.vaultPath, isDryRun);
+    const { rootContentIndex, allIndices } = await generateIndices({ vaultPath: site.vaultPath, dryRun: isDryRun });
 
     // Generate sitemaps based on the collected indices
-    await generateSitemaps(site.vaultPath, site.domain, rootContentIndex, allIndices, isDryRun);
+    await generateSitemaps({
+      vaultPath: site.vaultPath,
+      domain: site.domain,
+      rootContentIndex,
+      allIndices,
+      dryRun: isDryRun,
+    });
 
-    await syncSite(site, registry, isDryRun);
+    await syncSite({ site, registry, isDryRun });
 
     if (isDryRun) {
       console.log('\n✅ Dry run completed successfully!');
     } else {
-      await uploadRegistry(site, registry);
+      await uploadRegistry({ site, registry });
       console.log('\n✅ Sync and registry upload successfully completed!');
     }
   } catch (err: any) {

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -141,7 +141,7 @@ async function scanAndGenerate(
   dir: string,
   baseDir: string,
   dryRun: boolean,
-  domain: string,
+  domain: string | undefined,
   vaultPath: string,
   subSitemaps: string[]
 ): Promise<{ index: VaultDirectoryIndex; allDirs: string[] }> {
@@ -215,7 +215,7 @@ async function scanAndGenerate(
   }
 
   // Generate sitemap for this directory if it has pages and is NOT the root
-  if (pages.length > 0 && relDir !== '') {
+  if (domain && pages.length > 0 && relDir !== '') {
     const sitemapUrls = mapPagesToSitemapUrls(pages, domain, relDir);
     const sitemapContent = generateSitemapXml(sitemapUrls);
     const sitemapPath = join(vaultPath, 'public', relDir, SITEMAP_XML);
@@ -228,7 +228,7 @@ async function scanAndGenerate(
   return { index: indexData, allDirs };
 }
 
-async function generateIndices(vaultPath: string, domain: string, dryRun: boolean = false) {
+async function generateIndices(vaultPath: string, domain: string | undefined, dryRun: boolean = false) {
   const contentDir = join(vaultPath, 'content');
   if (!(await exists(contentDir))) {
     console.error(`⨯ Error: The required "content" directory is missing in the vault: ${vaultPath}`);
@@ -253,35 +253,39 @@ async function generateIndices(vaultPath: string, domain: string, dryRun: boolea
   }
 
   // Generate sitemaps
-  const rootPages = rootContentIndex.pages;
-  const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls(rootPages, domain) : [];
-
-  if (subSitemaps.length === 0) {
-    // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
-    if (sitemapUrls.length > 0) {
-      const sitemapContent = generateSitemapXml(sitemapUrls);
-      const sitemapPath = join(publicBaseDir, SITEMAP_XML);
-      await writeSitemapFile(sitemapPath, `public/${SITEMAP_XML}`, sitemapContent, dryRun, 'sitemap');
-    }
+  if (!domain) {
+    console.log('ℹ️  Skipping sitemap generation because "domain" is not configured in registry.json');
   } else {
-    // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
-    const sitemaps = [];
+    const rootPages = rootContentIndex.pages;
+    const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls(rootPages, domain) : [];
 
-    if (sitemapUrls.length > 0) {
-      const sitemapContent = generateSitemapXml(sitemapUrls);
-      const sitemapPath = join(publicBaseDir, SITEMAP_PAGES_XML);
-      await writeSitemapFile(sitemapPath, `public/${SITEMAP_PAGES_XML}`, sitemapContent, dryRun, 'root pages sitemap');
-      sitemaps.push({ loc: `https://${domain}/${SITEMAP_PAGES_XML}` });
-    }
+    if (subSitemaps.length === 0) {
+      // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
+      if (sitemapUrls.length > 0) {
+        const sitemapContent = generateSitemapXml(sitemapUrls);
+        const sitemapPath = join(publicBaseDir, SITEMAP_XML);
+        await writeSitemapFile(sitemapPath, `public/${SITEMAP_XML}`, sitemapContent, dryRun, 'sitemap');
+      }
+    } else {
+      // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
+      const sitemaps = [];
 
-    for (const subSitemap of subSitemaps) {
-      sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
-    }
+      if (sitemapUrls.length > 0) {
+        const sitemapContent = generateSitemapXml(sitemapUrls);
+        const sitemapPath = join(publicBaseDir, SITEMAP_PAGES_XML);
+        await writeSitemapFile(sitemapPath, `public/${SITEMAP_PAGES_XML}`, sitemapContent, dryRun, 'root pages sitemap');
+        sitemaps.push({ loc: `https://${domain}/${SITEMAP_PAGES_XML}` });
+      }
 
-    if (sitemaps.length > 0) {
-      const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
-      const sitemapIndexPath = join(publicBaseDir, SITEMAP_XML);
-      await writeSitemapFile(sitemapIndexPath, `public/${SITEMAP_XML}`, sitemapIndexContent, dryRun, 'master sitemap index');
+      for (const subSitemap of subSitemaps) {
+        sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
+      }
+
+      if (sitemaps.length > 0) {
+        const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
+        const sitemapIndexPath = join(publicBaseDir, SITEMAP_XML);
+        await writeSitemapFile(sitemapIndexPath, `public/${SITEMAP_XML}`, sitemapIndexContent, dryRun, 'master sitemap index');
+      }
     }
   }
   const publicFiles = (await exists(publicBaseDir)) ? await scanPublicFiles(publicBaseDir) : [];

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { getRegistry } from '../src/lib/registry';
 import { env } from '../src/lib/env';
-import { INDEX_JSON, ROOT_JSON, INDEX_SLUG } from '../src/lib/constants';
+import { INDEX_JSON, ROOT_JSON, INDEX_SLUG, SITEMAP_XML, SITEMAP_PAGES_XML } from '../src/lib/constants';
 import { PageMetadata, VaultDirectoryIndex, VaultRootIndex } from '../src/lib/vault';
 import { hasFlag, getFlagValue } from '../src/lib/cli';
 
@@ -83,6 +83,33 @@ function generateSitemapIndexXml(sitemaps: { loc: string; lastmod?: string }[]):
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${sitemapTags}
 </sitemapindex>`;
+}
+
+function mapPagesToSitemapUrls(pages: PageMetadata[], domain: string, relDir: string = '') {
+  return pages.map((p) => {
+    const urlPath = p.slug === INDEX_SLUG ? relDir : relDir ? `${relDir}/${p.slug}` : p.slug;
+    return {
+      loc: `https://${domain}/${urlPath}`,
+      lastmod: p.updatedAt || p.date,
+    };
+  });
+}
+
+async function writeSitemapFile(
+  fullPath: string,
+  relPath: string,
+  content: string,
+  dryRun: boolean,
+  label: string
+) {
+  if (!dryRun) {
+    const dir = join(fullPath, '..');
+    await mkdir(dir, { recursive: true });
+    await writeFile(fullPath, content);
+    console.log(`✨ Generated ${label} at ${relPath}`);
+  } else {
+    console.log(`[DRY RUN] Would generate ${label} at ${relPath}`);
+  }
 }
 
 async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<string[]> {
@@ -189,27 +216,14 @@ async function scanAndGenerate(
 
   // Generate sitemap for this directory if it has pages and is NOT the root
   if (pages.length > 0 && relDir !== '') {
-      const sitemapUrls = pages.map((p) => {
-        const path = p.slug === INDEX_SLUG ? relDir : `${relDir}/${p.slug}`;
-        return {
-          loc: `https://${domain}/${path}`,
-          lastmod: p.updatedAt || p.date,
-        };
-      });
+    const sitemapUrls = mapPagesToSitemapUrls(pages, domain, relDir);
+    const sitemapContent = generateSitemapXml(sitemapUrls);
+    const sitemapPath = join(vaultPath, 'public', relDir, SITEMAP_XML);
+    const relSitemapPath = `public/${relDir}/${SITEMAP_XML}`;
 
-      const sitemapContent = generateSitemapXml(sitemapUrls);
-      const sitemapPath = join(vaultPath, 'public', relDir, 'sitemap.xml');
-      const sitemapDir = join(vaultPath, 'public', relDir);
-
-      if (!dryRun) {
-        await mkdir(sitemapDir, { recursive: true });
-        await writeFile(sitemapPath, sitemapContent);
-        console.log(`✨ Generated sitemap for "${relDir}" at public/${relDir}/sitemap.xml`);
-      } else {
-        console.log(`[DRY RUN] Would generate sitemap for "${relDir}" at public/${relDir}/sitemap.xml`);
-      }
-      subSitemaps.push(`${relDir}/sitemap.xml`);
-    }
+    await writeSitemapFile(sitemapPath, relSitemapPath, sitemapContent, dryRun, `sitemap for "${relDir}"`);
+    subSitemaps.push(`${relDir}/${SITEMAP_XML}`);
+  }
 
   return { index: indexData, allDirs };
 }
@@ -240,46 +254,24 @@ async function generateIndices(vaultPath: string, domain: string, dryRun: boolea
 
   // Generate sitemaps
   const rootPages = rootContentIndex.pages;
+  const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls(rootPages, domain) : [];
+
   if (subSitemaps.length === 0) {
     // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
-    if (rootPages.length > 0) {
-      const sitemapUrls = rootPages.map((p) => {
-        const path = p.slug === INDEX_SLUG ? '' : p.slug;
-        return {
-          loc: `https://${domain}/${path}`,
-          lastmod: p.updatedAt || p.date,
-        };
-      });
+    if (sitemapUrls.length > 0) {
       const sitemapContent = generateSitemapXml(sitemapUrls);
-      const sitemapPath = join(publicBaseDir, 'sitemap.xml');
-      if (!dryRun) {
-        await writeFile(sitemapPath, sitemapContent);
-        console.log(`✨ Generated sitemap at public/sitemap.xml`);
-      } else {
-        console.log(`[DRY RUN] Would generate sitemap at public/sitemap.xml`);
-      }
+      const sitemapPath = join(publicBaseDir, SITEMAP_XML);
+      await writeSitemapFile(sitemapPath, `public/${SITEMAP_XML}`, sitemapContent, dryRun, 'sitemap');
     }
   } else {
     // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
     const sitemaps = [];
 
-    if (rootPages.length > 0) {
-      const sitemapUrls = rootPages.map((p) => {
-        const path = p.slug === INDEX_SLUG ? '' : p.slug;
-        return {
-          loc: `https://${domain}/${path}`,
-          lastmod: p.updatedAt || p.date,
-        };
-      });
+    if (sitemapUrls.length > 0) {
       const sitemapContent = generateSitemapXml(sitemapUrls);
-      const sitemapPath = join(publicBaseDir, 'sitemap_pages.xml');
-      if (!dryRun) {
-        await writeFile(sitemapPath, sitemapContent);
-        console.log(`✨ Generated root pages sitemap at public/sitemap_pages.xml`);
-      } else {
-        console.log(`[DRY RUN] Would generate root pages sitemap at public/sitemap_pages.xml`);
-      }
-      sitemaps.push({ loc: `https://${domain}/sitemap_pages.xml` });
+      const sitemapPath = join(publicBaseDir, SITEMAP_PAGES_XML);
+      await writeSitemapFile(sitemapPath, `public/${SITEMAP_PAGES_XML}`, sitemapContent, dryRun, 'root pages sitemap');
+      sitemaps.push({ loc: `https://${domain}/${SITEMAP_PAGES_XML}` });
     }
 
     for (const subSitemap of subSitemaps) {
@@ -288,13 +280,8 @@ async function generateIndices(vaultPath: string, domain: string, dryRun: boolea
 
     if (sitemaps.length > 0) {
       const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
-      const sitemapIndexPath = join(publicBaseDir, 'sitemap.xml');
-      if (!dryRun) {
-        await writeFile(sitemapIndexPath, sitemapIndexContent);
-        console.log(`✨ Generated master sitemap index at public/sitemap.xml`);
-      } else {
-        console.log(`[DRY RUN] Would generate master sitemap index at public/sitemap.xml`);
-      }
+      const sitemapIndexPath = join(publicBaseDir, SITEMAP_XML);
+      await writeSitemapFile(sitemapIndexPath, `public/${SITEMAP_XML}`, sitemapIndexContent, dryRun, 'master sitemap index');
     }
   }
   const publicFiles = (await exists(publicBaseDir)) ? await scanPublicFiles(publicBaseDir) : [];

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -23,12 +23,21 @@ async function exists(path: string) {
   }
 }
 
-async function execAsync({ command, options }: { command: string; options: SpawnOptions }): Promise<void> {
+async function execAsync({
+  command,
+  args,
+  options,
+}: {
+  command: string;
+  args: string[];
+  options: SpawnOptions;
+}): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, { ...options, shell: true });
+    // shell: false is more secure and robust against special characters
+    const child = spawn(command, args, { ...options, shell: false });
     child.on('close', (code) => {
       if (code === 0) resolve();
-      else reject(new Error(`Command failed with code ${code}`));
+      else reject(new Error(`Command "${command} ${args.join(' ')}" failed with code ${code}`));
     });
     child.on('error', (err) => reject(err));
   });
@@ -351,25 +360,32 @@ async function syncSite({ site, registry, isDryRun }: { site: Site; registry: Re
   // We add a trailing slash to the vaultPath so that aws s3 sync syncs the *contents* of the directory
   // and not the directory itself.
   // Each site is synced to its own subdirectory in the bucket: /{site-id}/*
-  const syncCommand = [
-    'aws s3 sync',
-    `"${site.vaultPath}/"`,
-    `"s3://${site.bucketName}/${site.siteId}/"`,
-    `--endpoint-url "${endpoint}"`,
-    `--exclude "*.DS_Store"`,
-    `--exclude "*/.git/*"`,
-    `--exclude ".git/*"`,
-    `--delete`, // Automatically delete remote files that don't exist locally
-    isDryRun ? '--dryrun' : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const args = [
+    's3',
+    'sync',
+    `${site.vaultPath}/`,
+    `s3://${site.bucketName}/${site.siteId}/`,
+    '--endpoint-url',
+    endpoint,
+    '--exclude',
+    '*.DS_Store',
+    '--exclude',
+    '*/.git/*',
+    '--exclude',
+    '.git/*',
+    '--delete',
+  ];
 
-  console.log(`Executing:\n> ${syncCommand}\n`);
+  if (isDryRun) {
+    args.push('--dryrun');
+  }
+
+  console.log(`Executing:\n> aws ${args.join(' ')}\n`);
 
   // stdio: 'inherit' passes the aws-cli output directly to our terminal
   await execAsync({
-    command: syncCommand,
+    command: 'aws',
+    args,
     options: {
       stdio: 'inherit',
       env: {
@@ -407,15 +423,11 @@ async function uploadRegistry({ site, registry }: { site: Site; registry: Regist
   try {
     await writeFile(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
 
-    const uploadRegistryCommand = [
-      'aws s3 cp',
-      `"${registryTmpPath}"`,
-      `"s3://${site.bucketName}/registry.json"`,
-      `--endpoint-url "${endpoint}"`,
-    ].join(' ');
+    const args = ['s3', 'cp', registryTmpPath, `s3://${site.bucketName}/registry.json`, '--endpoint-url', endpoint];
 
     await execAsync({
-      command: uploadRegistryCommand,
+      command: 'aws',
+      args,
       options: {
         stdio: 'inherit',
         env: {
@@ -585,9 +597,13 @@ async function main() {
       console.log('\n✅ Sync and registry upload successfully completed!');
     }
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
     console.error(`\n⨯ ${isDryRun ? 'Dry run' : 'Sync process'} failed.`);
-    console.error(message);
+    if (err instanceof Error) {
+      console.error(err.message);
+    } else {
+      console.error('An unknown error occurred:');
+      console.error(err);
+    }
     process.exit(1);
   }
 }

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -11,6 +11,7 @@ import { env } from '../src/lib/env';
 import { INDEX_JSON, ROOT_JSON, INDEX_SLUG, SITEMAP_XML, SITEMAP_PAGES_XML } from '../src/lib/constants';
 import { PageMetadata, VaultDirectoryIndex, VaultRootIndex } from '../src/lib/vault';
 import { hasFlag, getFlagValue } from '../src/lib/cli';
+import { Registry, Site } from '../src/domain/registry';
 
 async function exists(path: string) {
   try {
@@ -137,13 +138,33 @@ async function scanPublicFiles(dir: string, baseDir: string = dir): Promise<stri
   return files;
 }
 
+async function generateAllSitemaps(
+  domain: string,
+  allIndices: Map<string, VaultDirectoryIndex>,
+  vaultPath: string,
+  dryRun: boolean
+): Promise<string[]> {
+  const subSitemaps: string[] = [];
+  for (const [relDir, indexData] of allIndices.entries()) {
+    if (relDir === '') continue; // Skip root, handled separately
+    if (indexData.pages.length === 0) continue;
+
+    const sitemapUrls = mapPagesToSitemapUrls(indexData.pages, domain, relDir);
+    const sitemapContent = generateSitemapXml(sitemapUrls);
+    const sitemapPath = join(vaultPath, 'public', relDir, SITEMAP_XML);
+    const relSitemapPath = `public/${relDir}/${SITEMAP_XML}`;
+
+    await writeSitemapFile(sitemapPath, relSitemapPath, sitemapContent, dryRun, `sitemap for "${relDir}"`);
+    subSitemaps.push(`${relDir}/${SITEMAP_XML}`);
+  }
+  return subSitemaps;
+}
+
 async function scanAndGenerate(
   dir: string,
   baseDir: string,
   dryRun: boolean,
-  domain: string | undefined,
-  vaultPath: string,
-  subSitemaps: string[]
+  allIndices: Map<string, VaultDirectoryIndex>
 ): Promise<{ index: VaultDirectoryIndex; allDirs: string[] }> {
   const entries = await readdir(dir, { withFileTypes: true });
   const pages: PageMetadata[] = [];
@@ -156,7 +177,7 @@ async function scanAndGenerate(
 
     if (entry.isDirectory()) {
       if (entry.name !== '.git' && entry.name !== 'node_modules') {
-        const result = await scanAndGenerate(fullPath, baseDir, dryRun, domain, vaultPath, subSitemaps);
+        const result = await scanAndGenerate(fullPath, baseDir, dryRun, allIndices);
 
         const childRelDir = relative(baseDir, fullPath).replace(/\\/g, '/');
         allDirs.push(childRelDir, ...result.allDirs);
@@ -214,21 +235,136 @@ async function scanAndGenerate(
     console.log(`✨ Generated index for "${relDirName}"`);
   }
 
-  // Generate sitemap for this directory if it has pages and is NOT the root
-  if (domain && pages.length > 0 && relDir !== '') {
-    const sitemapUrls = mapPagesToSitemapUrls(pages, domain, relDir);
-    const sitemapContent = generateSitemapXml(sitemapUrls);
-    const sitemapPath = join(vaultPath, 'public', relDir, SITEMAP_XML);
-    const relSitemapPath = `public/${relDir}/${SITEMAP_XML}`;
-
-    await writeSitemapFile(sitemapPath, relSitemapPath, sitemapContent, dryRun, `sitemap for "${relDir}"`);
-    subSitemaps.push(`${relDir}/${SITEMAP_XML}`);
-  }
+  allIndices.set(relDir, indexData);
 
   return { index: indexData, allDirs };
 }
 
-async function generateIndices(vaultPath: string, domain: string | undefined, dryRun: boolean = false) {
+async function selectSite(registry: Registry): Promise<Site> {
+  const siteId = await select({
+    message: 'Select a site to sync using AWS CLI:',
+    choices: registry.sites.map((site) => ({
+      name: `${site.siteId} (${site.domain || 'no domain'})`,
+      value: site.siteId,
+      description: `Vault: ${site.vaultPath} -> Bucket: ${site.bucketName || 'Not configured'}`,
+    })),
+  });
+
+  const site = registry.sites.find((s) => s.siteId === siteId);
+  if (!site) {
+    console.error('⨯ Site not found in registry.json');
+    process.exit(1);
+  }
+
+  if (!site.bucketName) {
+    console.error(`⨯ Error: "bucketName" is not configured for site [${site.siteId}] in registry.json`);
+    process.exit(1);
+  }
+
+  if (!(await exists(site.vaultPath))) {
+    console.error(`⨯ Error: The local vaultPath does not exist: ${site.vaultPath}`);
+    process.exit(1);
+  }
+
+  return site;
+}
+
+async function syncSite(site: Site, registry: Registry, isDryRun: boolean) {
+  const endpoint = site.endpoint || registry.endpoint || env.S3_ENDPOINT;
+  const accessKeyId = registry.accessKeyId || env.S3_ACCESS_KEY_ID;
+  const secretAccessKey = registry.secretAccessKey || env.S3_SECRET_ACCESS_KEY;
+
+  if (!endpoint || !accessKeyId || !secretAccessKey) {
+    console.error(
+      '⨯ Error: Missing S3 credentials. Please provide them in registry.json or via environment variables (S3_ENDPOINT, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY).'
+    );
+    process.exit(1);
+  }
+
+  console.log(`\n☁️  Preparing AWS S3 Sync...`);
+  console.log(`- Local Path: ${site.vaultPath}`);
+  console.log(`- S3 Bucket:  ${site.bucketName}`);
+  console.log(`- Endpoint:   ${endpoint}\n`);
+
+  // We add a trailing slash to the vaultPath so that aws s3 sync syncs the *contents* of the directory
+  // and not the directory itself.
+  // Each site is synced to its own subdirectory in the bucket: /{site-id}/*
+  const syncCommand = [
+    'aws s3 sync',
+    `"${site.vaultPath}/"`,
+    `"s3://${site.bucketName}/${site.siteId}/"`,
+    `--endpoint-url "${endpoint}"`,
+    `--exclude "*.DS_Store"`,
+    `--exclude "*/.git/*"`,
+    `--exclude ".git/*"`,
+    `--delete`, // Automatically delete remote files that don't exist locally
+    isDryRun ? '--dryrun' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  console.log(`Executing:\n> ${syncCommand}\n`);
+
+  // stdio: 'inherit' passes the aws-cli output directly to our terminal
+  await execAsync(syncCommand, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      AWS_ACCESS_KEY_ID: accessKeyId,
+      AWS_SECRET_ACCESS_KEY: secretAccessKey,
+    },
+  });
+}
+
+async function uploadRegistry(site: Site, registry: Registry) {
+  const endpoint = site.endpoint || registry.endpoint || env.S3_ENDPOINT;
+  const accessKeyId = registry.accessKeyId || env.S3_ACCESS_KEY_ID;
+  const secretAccessKey = registry.secretAccessKey || env.S3_SECRET_ACCESS_KEY;
+
+  if (!endpoint || !accessKeyId || !secretAccessKey) return;
+
+  console.log('\n✨ Uploading sanitized registry.json to bucket root...');
+
+  // Sanitize registry: remove sensitive credentials and local vault paths
+  const sanitizedSites = registry.sites
+    .filter((s) => s.bucketName === site.bucketName)
+    .map((s) => ({
+      domain: s.domain,
+      siteId: s.siteId,
+      // vaultPath is omitted or can be a placeholder
+    }));
+
+  const sanitizedRegistry = {
+    sites: sanitizedSites,
+  };
+
+  const registryTmpPath = join(tmpdir(), `notopress-registry-${randomUUID()}.json`);
+  try {
+    await writeFile(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
+
+    const uploadRegistryCommand = [
+      'aws s3 cp',
+      `"${registryTmpPath}"`,
+      `"s3://${site.bucketName}/registry.json"`,
+      `--endpoint-url "${endpoint}"`,
+    ].join(' ');
+
+    await execAsync(uploadRegistryCommand, {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: accessKeyId,
+        AWS_SECRET_ACCESS_KEY: secretAccessKey,
+      },
+    });
+  } finally {
+    if (await exists(registryTmpPath)) {
+      await unlink(registryTmpPath);
+    }
+  }
+}
+
+async function generateIndices(vaultPath: string, dryRun: boolean = false) {
   const contentDir = join(vaultPath, 'content');
   if (!(await exists(contentDir))) {
     console.error(`⨯ Error: The required "content" directory is missing in the vault: ${vaultPath}`);
@@ -237,14 +373,12 @@ async function generateIndices(vaultPath: string, domain: string | undefined, dr
 
   // 1. Recursive generation of index.json for each level in content/
   console.log(`\n🔍 Recursively scanning "content" directory in ${contentDir}...`);
-  const subSitemaps: string[] = [];
+  const allIndices = new Map<string, VaultDirectoryIndex>();
   const { index: rootContentIndex, allDirs } = await scanAndGenerate(
     contentDir,
     contentDir,
     dryRun,
-    domain,
-    vaultPath,
-    subSitemaps
+    allIndices
   );
 
   const publicBaseDir = join(vaultPath, 'public');
@@ -252,42 +386,6 @@ async function generateIndices(vaultPath: string, domain: string | undefined, dr
     await mkdir(publicBaseDir, { recursive: true });
   }
 
-  // Generate sitemaps
-  if (!domain) {
-    console.log('ℹ️  Skipping sitemap generation because "domain" is not configured in registry.json');
-  } else {
-    const rootPages = rootContentIndex.pages;
-    const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls(rootPages, domain) : [];
-
-    if (subSitemaps.length === 0) {
-      // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
-      if (sitemapUrls.length > 0) {
-        const sitemapContent = generateSitemapXml(sitemapUrls);
-        const sitemapPath = join(publicBaseDir, SITEMAP_XML);
-        await writeSitemapFile(sitemapPath, `public/${SITEMAP_XML}`, sitemapContent, dryRun, 'sitemap');
-      }
-    } else {
-      // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
-      const sitemaps = [];
-
-      if (sitemapUrls.length > 0) {
-        const sitemapContent = generateSitemapXml(sitemapUrls);
-        const sitemapPath = join(publicBaseDir, SITEMAP_PAGES_XML);
-        await writeSitemapFile(sitemapPath, `public/${SITEMAP_PAGES_XML}`, sitemapContent, dryRun, 'root pages sitemap');
-        sitemaps.push({ loc: `https://${domain}/${SITEMAP_PAGES_XML}` });
-      }
-
-      for (const subSitemap of subSitemaps) {
-        sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
-      }
-
-      if (sitemaps.length > 0) {
-        const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
-        const sitemapIndexPath = join(publicBaseDir, SITEMAP_XML);
-        await writeSitemapFile(sitemapIndexPath, `public/${SITEMAP_XML}`, sitemapIndexContent, dryRun, 'master sitemap index');
-      }
-    }
-  }
   const publicFiles = (await exists(publicBaseDir)) ? await scanPublicFiles(publicBaseDir) : [];
 
   // 2. Generate root.json at vault root pointing to top-level content
@@ -304,136 +402,84 @@ async function generateIndices(vaultPath: string, domain: string | undefined, dr
     await writeFile(rootPath, JSON.stringify(vaultRootIndex, null, 2));
     console.log(`✨ Generated master root index with ${allDirs.length} directories at: ${rootPath}`);
   }
+
+  return { rootContentIndex, allIndices };
+}
+
+async function generateSitemaps(
+  vaultPath: string,
+  domain: string | undefined,
+  rootContentIndex: VaultDirectoryIndex,
+  allIndices: Map<string, VaultDirectoryIndex>,
+  dryRun: boolean
+) {
+  if (!domain) {
+    console.log('ℹ️  Skipping sitemap generation because "domain" is not configured in registry.json');
+    return;
+  }
+
+  const publicBaseDir = join(vaultPath, 'public');
+  const subSitemaps = await generateAllSitemaps(domain, allIndices, vaultPath, dryRun);
+  const rootPages = rootContentIndex.pages;
+  const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls(rootPages, domain) : [];
+
+  if (subSitemaps.length === 0) {
+    // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
+    if (sitemapUrls.length > 0) {
+      const sitemapContent = generateSitemapXml(sitemapUrls);
+      const sitemapPath = join(publicBaseDir, SITEMAP_XML);
+      await writeSitemapFile(sitemapPath, `public/${SITEMAP_XML}`, sitemapContent, dryRun, 'sitemap');
+    }
+  } else {
+    // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
+    const sitemaps = [];
+
+    if (sitemapUrls.length > 0) {
+      const sitemapContent = generateSitemapXml(sitemapUrls);
+      const sitemapPath = join(publicBaseDir, SITEMAP_PAGES_XML);
+      await writeSitemapFile(sitemapPath, `public/${SITEMAP_PAGES_XML}`, sitemapContent, dryRun, 'root pages sitemap');
+      sitemaps.push({ loc: `https://${domain}/${SITEMAP_PAGES_XML}` });
+    }
+
+    for (const subSitemap of subSitemaps) {
+      sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
+    }
+
+    if (sitemaps.length > 0) {
+      const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
+      const sitemapIndexPath = join(publicBaseDir, SITEMAP_XML);
+      await writeSitemapFile(sitemapIndexPath, `public/${SITEMAP_XML}`, sitemapIndexContent, dryRun, 'master sitemap index');
+    }
+  }
 }
 
 async function main() {
   const isDryRun = hasFlag({ flag: '--dry-run' });
-
-  // Parse registry path from command line arguments
   const registryPath = getFlagValue({ flag: '--registry', alias: '-r' });
 
-  const registry = await getRegistry(registryPath);
-
-  if (isDryRun) {
-    console.log('\n🏜️  DRY RUN MODE ENABLED - No changes will be made.');
-  }
-
-  const siteId = await select({
-    message: 'Select a site to sync using AWS CLI:',
-    choices: registry.sites.map(site => ({
-      name: `${site.siteId} (${site.domain})`,
-      value: site.siteId,
-      description: `Vault: ${site.vaultPath} -> Bucket: ${site.bucketName || 'Not configured'}`,
-    })),
-  });
-
-  const site = registry.sites.find(s => s.siteId === siteId);
-  if (!site) {
-    console.error('⨯ Site not found in registry.json');
-    process.exit(1);
-  }
-
-  if (!site.bucketName) {
-    console.error(`⨯ Error: "bucketName" is not configured for site [${site.siteId}] in registry.json`);
-    process.exit(1);
-  }
-
-  if (!(await exists(site.vaultPath))) {
-    console.error(`⨯ Error: The local vaultPath does not exist: ${site.vaultPath}`);
-    process.exit(1);
-  }
-
-  // Generate index files at every level and root.json at the vault root before syncing
-  await generateIndices(site.vaultPath, site.domain, isDryRun);
-
-  const endpoint = registry.endpoint || env.S3_ENDPOINT;
-  const accessKeyId = registry.accessKeyId || env.S3_ACCESS_KEY_ID;
-  const secretAccessKey = registry.secretAccessKey || env.S3_SECRET_ACCESS_KEY;
-
-  if (!endpoint || !accessKeyId || !secretAccessKey) {
-    console.error('⨯ Error: Missing S3 credentials. Please provide them in registry.json or via environment variables (S3_ENDPOINT, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY).');
-    process.exit(1);
-  }
-
-  console.log(`\n☁️  Preparing AWS S3 Sync...`);
-  console.log(`- Local Path: ${site.vaultPath}`);
-  console.log(`- S3 Bucket:  ${site.bucketName}`);
-  console.log(`- Endpoint:   ${endpoint}\n`);
-
   try {
-    // We add a trailing slash to the vaultPath so that aws s3 sync syncs the *contents* of the directory
-    // and not the directory itself.
-    // Each site is synced to its own subdirectory in the bucket: /{site-id}/*
-    const syncCommand = [
-      'aws s3 sync',
-      `"${site.vaultPath}/"`,
-      `"s3://${site.bucketName}/${site.siteId}/"`,
-      `--endpoint-url "${endpoint}"`,
-      `--exclude "*.DS_Store"`,
-      `--exclude "*/.git/*"`,
-      `--exclude ".git/*"`,
-      `--delete`, // Automatically delete remote files that don't exist locally
-      isDryRun ? '--dryrun' : ''
-    ].filter(Boolean).join(' ');
+    const registry = await getRegistry(registryPath);
 
-    console.log(`Executing:\n> ${syncCommand}\n`);
+    if (isDryRun) {
+      console.log('\n🏜️  DRY RUN MODE ENABLED - No changes will be made.');
+    }
 
-    // stdio: 'inherit' passes the aws-cli output directly to our terminal
-    await execAsync(syncCommand, {
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        AWS_ACCESS_KEY_ID: accessKeyId,
-        AWS_SECRET_ACCESS_KEY: secretAccessKey
-      }
-    });
+    const site = await selectSite(registry);
+
+    // Generate index files at every level and root.json at the vault root
+    const { rootContentIndex, allIndices } = await generateIndices(site.vaultPath, isDryRun);
+
+    // Generate sitemaps based on the collected indices
+    await generateSitemaps(site.vaultPath, site.domain, rootContentIndex, allIndices, isDryRun);
+
+    await syncSite(site, registry, isDryRun);
 
     if (isDryRun) {
       console.log('\n✅ Dry run completed successfully!');
     } else {
-      console.log('\n✨ Uploading sanitized registry.json to bucket root...');
-
-      // Sanitize registry: remove sensitive credentials and local vault paths
-      const sanitizedSites = registry.sites
-        .filter(s => s.bucketName === site.bucketName)
-        .map(s => ({
-          domain: s.domain,
-          siteId: s.siteId,
-          // vaultPath is omitted or can be a placeholder
-        }));
-
-      const sanitizedRegistry = {
-        sites: sanitizedSites
-      };
-
-      const registryTmpPath = join(tmpdir(), `notopress-registry-${randomUUID()}.json`);
-      try {
-        await writeFile(registryTmpPath, JSON.stringify(sanitizedRegistry, null, 2));
-
-        const uploadRegistryCommand = [
-          'aws s3 cp',
-          `"${registryTmpPath}"`,
-          `"s3://${site.bucketName}/registry.json"`,
-          `--endpoint-url "${endpoint}"`,
-        ].join(' ');
-
-        await execAsync(uploadRegistryCommand, {
-          stdio: 'inherit',
-          env: {
-            ...process.env,
-            AWS_ACCESS_KEY_ID: accessKeyId,
-            AWS_SECRET_ACCESS_KEY: secretAccessKey
-          }
-        });
-      } finally {
-        if (await exists(registryTmpPath)) {
-          await unlink(registryTmpPath);
-        }
-      }
-
+      await uploadRegistry(site, registry);
       console.log('\n✅ Sync and registry upload successfully completed!');
     }
-
   } catch (err: any) {
     console.error(`\n⨯ ${isDryRun ? 'Dry run' : 'Sync process'} failed.`);
     console.error(err.message);

--- a/skills/coding-conventions.md
+++ b/skills/coding-conventions.md
@@ -1,0 +1,60 @@
+# Coding Conventions
+
+This document outlines the coding standards and best practices for the Notopress repository. All contributors and AI agents must follow these rules to ensure consistency, maintainability, and type safety.
+
+## 1. Type Safety & Explicit Types
+
+### 1.1 Avoid `any`
+- Never use the `any` type. It bypasses TypeScript's type checking and introduces bugs.
+- Use `unknown` if the type is truly unknown, then narrow it down with type guards or schemas.
+- For external data (API responses, file parsing), always use an explicit interface or type.
+
+### 1.2 Avoid Force Casting (`as`)
+- Avoid using the `as` keyword for force casting (type assertions).
+- Instead of `data as MyType`, use **Zod schemas** to safe-parse the data. This ensures the data actually matches the expected structure at runtime.
+
+```typescript
+// ❌ Avoid
+const user = data as User;
+
+// ✅ Preferred
+const result = UserSchema.safeParse(data);
+if (!result.success) {
+  // Handle error
+}
+const user = result.data;
+```
+
+## 2. Function Design
+
+### 2.1 Named Parameters
+- Functions with more than one argument should use a single object as input (named parameters).
+- This improves readability at the call site and makes it easier to add or remove parameters without breaking order.
+
+```typescript
+// ❌ Avoid
+function sync(path: string, bucket: string, dryRun: boolean) { ... }
+
+// ✅ Preferred
+function sync({ path, bucket, dryRun }: { path: string; bucket: string; dryRun: boolean }) { ... }
+```
+
+### 2.2 Separation of Concerns
+- Functions should have a single responsibility.
+- Large orchestrators (like `main`) should call smaller, focused helper functions rather than implementing the logic directly.
+
+## 3. Configuration & Constants
+
+### 3.1 Use Shared Constants
+- Never hardcode strings like filenames (`index.json`, `sitemap.xml`) or slugs.
+- Use the shared constants defined in `src/lib/constants.ts`.
+
+### 3.2 Optional vs. Required
+- Make configuration fields optional if they are not strictly required for all modes of operation.
+- Gracefully handle the absence of optional fields (e.g., skip sitemap generation if `domain` is missing).
+
+## 4. Error Handling
+
+- Always use `try...catch` blocks for asynchronous operations.
+- In `catch` blocks, treat the error as `unknown` and use type guards to safely access properties like `message`.
+- Provide user-friendly error messages that explain *what* failed and *why*.

--- a/skills/coding-conventions/SKILL.md
+++ b/skills/coding-conventions/SKILL.md
@@ -1,3 +1,8 @@
+---
+title: Coding Conventions
+description: Standards and best practices for the Notopress repository.
+---
+
 # Coding Conventions
 
 This document outlines the coding standards and best practices for the Notopress repository. All contributors and AI agents must follow these rules to ensure consistency, maintainability, and type safety.

--- a/skills/coding-conventions/SKILL.md
+++ b/skills/coding-conventions/SKILL.md
@@ -61,5 +61,23 @@ function sync({ path, bucket, dryRun }: { path: string; bucket: string; dryRun: 
 ## 4. Error Handling
 
 - Always use `try...catch` blocks for asynchronous operations.
-- In `catch` blocks, treat the error as `unknown` and use type guards to safely access properties like `message`.
+- In `catch` blocks, treat the error as `unknown`.
+- If the error is an instance of `Error`, log its `message`.
+- If the error is not an `Error` object, log the entire object or use `JSON.stringify` to ensure helpful debugging information is captured (avoiding unhelpful `[object Object]` outputs).
 - Provide user-friendly error messages that explain *what* failed and *why*.
+
+## 5. Command Execution
+
+- When executing external commands (e.g., using `spawn`), always use an **argument array** instead of a single command string.
+- Avoid using `shell: true` whenever possible. It is more secure and robust against special characters in paths or names.
+- Manual quoting of arguments is fragile; letting the OS handle the argument array is the standard practice.
+
+```typescript
+// ❌ Avoid
+const cmd = `aws s3 sync "${path}" "s3://${bucket}"`;
+spawn(cmd, { shell: true });
+
+// ✅ Preferred
+const args = ['s3', 'sync', path, `s3://${bucket}`];
+spawn('aws', args, { shell: false });
+```

--- a/skills/pull-request/SKILL.md
+++ b/skills/pull-request/SKILL.md
@@ -1,3 +1,8 @@
+---
+title: Pull Request Creation
+description: Guidelines and automation patterns for creating pull requests using GitHub CLI.
+---
+
 # Pull Request Skill
 
 When creating pull requests for this repository, follow these guidelines:

--- a/skills/registry-migration/SKILL.md
+++ b/skills/registry-migration/SKILL.md
@@ -1,9 +1,14 @@
+---
+title: Registry Migration
+description: Guidelines for migrating registry.json data to match the latest schema.
+---
+
 # Registry Migration Skill
 
 As the project evolves, the structure of `registry.json` may change. This skill provides guidelines for migrating your registry data to match the latest schema.
 
 ## Schema Source of Truth
-The canonical schema is defined in [src/domain/registry.ts](../src/domain/registry.ts) using Zod. Always refer to this file to see the expected structure.
+The canonical schema is defined in [src/domain/registry.ts](../../src/domain/registry.ts) using Zod. Always refer to this file to see the expected structure.
 
 ## Migration Workflow
 

--- a/src/domain/registry.ts
+++ b/src/domain/registry.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const SiteSchema = z.object({
-  domain: z.string(),
+  domain: z.string().optional(),
   siteId: z.string(),
   vaultPath: z.string(),
   bucketName: z.string().optional(),

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,6 +18,16 @@ export const INDEX_JSON = 'index.json';
 export const ROOT_JSON = 'root.json';
 
 /**
+ * The filename for the default sitemap.
+ */
+export const SITEMAP_XML = 'sitemap.xml';
+
+/**
+ * The filename for the sitemap containing individual pages.
+ */
+export const SITEMAP_PAGES_XML = 'sitemap_pages.xml';
+
+/**
  * The default filename for the registry configuration.
  */
 export const DEFAULT_REGISTRY_FILENAME = 'registry.json';


### PR DESCRIPTION
This PR fixes an issue where the sitemap generation failed with ENOENT if the public/ directory did not exist in the vault root. It also refines the naming logic to produce a cleaner sitemap structure depending on whether sub-directories with content exist.

Key changes:
1. Added a recursive directory creation step for the public directory in `scripts/sync.ts`.
2. Reorganized the sitemap generation logic to conditionally choose between a single sitemap file or a sitemap index based on the presence of sub-sitemaps.
3. Verified both "root-only" and "nested content" scenarios using a test vault and confirmed the output file structure and content.

Fixes #27

---
*PR created automatically by Jules for task [3545322594682059254](https://jules.google.com/task/3545322594682059254) started by @speshiou*