### PR TITLE
feat: responsive thumbnails, WordPress publishing, and Obsidian wikilinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@ Always run `npm run type-check` after making changes to verify basic syntax erro
 - Keep main entrance files clean as orchestrators. Move feature logic, parsing, file scanning, rendering transforms, and other reusable behavior into focused modules instead of letting scripts or page files grow bloated.
 - Module functions should strictly follow dependency injection patterns: pass filesystem, network, parser, logger, process, and other side-effect dependencies through explicit factory inputs or function parameters so modules stay extensible and testable.
 - Add unit tests beside the module file at the same directory level whenever creating or substantially changing a module.
+- **Single Source of Truth**: Strictly avoid duplicating code, logic, data structures, configurations, patterns (such as URL/path composition, file/folder resolution, parsing, etc.), or abstractions across the codebase. Always consolidate them into centralized, reusable modules and helper functions (e.g., in `src/lib/` or `scripts/lib/`) to maintain a single source of truth across all scripts, tools, and the frontend application.
+- **Layered Architecture & Cross-Imports**: Strictly maintain a unidirectional layered dependency model. Under no circumstances should cross-layer or circular imports occur:
+  - **Domain layer** (`src/domain/`) holds pure types and configurations. It must never import from other layers.
+  - **Library layer** (`src/lib/`) contains business logic/services. It can import from `src/domain/`, but never from the application (`src/app/`) or scripts (`scripts/`).
+  - **Application/Presentation layer** (`src/app/` / Next.js) can import from `src/lib/` and `src/domain/`.
+  - **Scripts layer** (`scripts/` / CLI tools) can import from `src/lib/`, `src/domain/`, and local script helpers (`scripts/lib/`).
+
 
 # Privacy & Paths
 - **Never** include absolute filesystem paths (e.g., `/Users/username/...`) in any code, documentation, or commit messages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,9 @@ This version has breaking changes — APIs, conventions, and file structure may 
 <!-- END:nextjs-agent-rules -->
 
 # Verification
-Always run `npm run type-check` after making changes to verify basic syntax errors.
+- Always run `npm run type-check` after making changes to verify basic syntax errors.
+- **Strictly avoid using `any` type** anywhere in the codebase. Always write proper TypeScript types, schemas, or interfaces for safety and clarity.
+
 
 # Architecture
 - Keep main entrance files clean as orchestrators. Move feature logic, parsing, file scanning, rendering transforms, and other reusable behavior into focused modules instead of letting scripts or page files grow bloated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,11 @@ This version has breaking changes — APIs, conventions, and file structure may 
 # Verification
 Always run `npm run type-check` after making changes to verify basic syntax errors.
 
+# Architecture
+- Keep main entrance files clean as orchestrators. Move feature logic, parsing, file scanning, rendering transforms, and other reusable behavior into focused modules instead of letting scripts or page files grow bloated.
+- Module functions should strictly follow dependency injection patterns: pass filesystem, network, parser, logger, process, and other side-effect dependencies through explicit factory inputs or function parameters so modules stay extensible and testable.
+- Add unit tests beside the module file at the same directory level whenever creating or substantially changing a module.
+
 # Privacy & Paths
 - **Never** include absolute filesystem paths (e.g., `/Users/username/...`) in any code, documentation, or commit messages.
 - Always use **relative paths** for internal links and documentation.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The registry manages global defaults and site-specific overrides.
 | `endpoint` | `string` | Your S3-compatible API endpoint (e.g., Cloudflare R2). |
 | `accessKeyId` | `string` | Your S3 access key ID. |
 | `secretAccessKey` | `string` | Your S3 secret access key. |
+| `thumbnailSizes` | `number[]` | (Optional) Default responsive image thumbnail widths. Defaults to `[320, 640, 960, 1280]`. |
 | `sites` | `array` | List of site configurations. |
 
 **Site-Specific Settings**
@@ -73,6 +74,21 @@ The registry manages global defaults and site-specific overrides.
 | `vaultPath` | `string` | Absolute path to your local markdown vault. |
 | `bucketName` | `string` | (Optional) The S3 bucket name. |
 | `endpoint` | `string` | (Optional) Override the global endpoint for this site. |
+| `thumbnailSizes` | `number[]` | (Optional) Override the global responsive image thumbnail widths for this site. |
+
+### Responsive Images
+
+When you run `npm run sync`, Notopress creates WebP thumbnails for supported images in `content/` and `public/`, then includes them in generated responsive `srcset` attributes at render time.
+
+Generated thumbnails live under `_thumbnails/` beside the source tree that owns the image. For example, an image referenced as `/attachments/photo.png` gets thumbnail candidates like `/_thumbnails/attachments/photo-640.webp`.
+
+### Serving Thumbnails from Cloudflare
+
+If your bucket is Cloudflare R2, the default deployment already stores thumbnails in R2 and serves them through the app's asset route with long-lived cache headers. To serve them directly from Cloudflare instead:
+
+1. Add a public or custom domain to the R2 bucket in Cloudflare.
+2. Keep the same uploaded key layout, including `{siteId}/content/_thumbnails/...` and `{siteId}/public/_thumbnails/...`.
+3. Point image URLs at that R2 domain with a future CDN URL setting, or add a rewrite in your edge/CDN layer from `/_thumbnails/...` to the matching R2 key.
 
 ### Environment Overrides
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "19.2.4",
         "remark": "^15.0.1",
         "remark-html": "^16.0.1",
+        "sharp": "^0.34.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -29,7 +30,7 @@
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5",
-        "vercel": "^51.8.0",
+        "vercel": "^54.11.1",
         "vitest": "^4.1.4"
       }
     },
@@ -875,13 +876,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -928,6 +929,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1197,32 +1199,10 @@
         "node": ">=16"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2797,9 +2777,9 @@
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2807,6 +2787,238 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2965,6 +3177,18 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3314,14 +3538,14 @@
       }
     },
     "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -3617,22 +3841,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3701,9 +3913,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4233,9 +4445,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4806,9 +5018,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4894,6 +5106,7 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4904,6 +5117,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4969,6 +5183,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5123,9 +5338,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5495,18 +5710,17 @@
       ]
     },
     "node_modules/@vercel/backends": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.1.2.tgz",
-      "integrity": "sha512-hkE5QpbueWYVZqbolsqR6s+3uSxSvrzSZqoJhM/TzF2BSzwrjZvYjckrppopPFezYu14h5rkxUsLXsjnTVWGLQ==",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.8.10.tgz",
+      "integrity": "sha512-74k8PeIzKZ3/Cl20mrU3uBf1U+EsTYJZrhjehwBqwzLrm+NQsRY6UUhEID0rWMQS8jdW+iTYMtjlscXYmmtIVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/build-utils": "13.19.1",
-        "@vercel/nft": "1.5.0",
-        "@yarnpkg/parsers": "^3.0.0",
+        "@vercel/build-utils": "13.29.0",
+        "@vercel/nft": "1.10.0",
         "execa": "3.2.0",
         "fs-extra": "11.1.0",
-        "js-yaml": "^3.13.1",
+        "get-port": "5.1.1",
         "oxc-transform": "0.111.0",
         "path-to-regexp": "8.3.0",
         "resolve.exports": "2.0.3",
@@ -5514,20 +5728,17 @@
         "srvx": "0.8.9",
         "tsx": "4.21.0",
         "zod": "3.22.4"
-      },
-      "peerDependencies": {
-        "typescript": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@vercel/backends/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -5776,30 +5987,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@vercel/backends/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@vercel/backends/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@vercel/backends/node_modules/rolldown": {
       "version": "1.0.0-rc.1",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.1.tgz",
@@ -5843,9 +6030,9 @@
       }
     },
     "node_modules/@vercel/blob": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.0.tgz",
-      "integrity": "sha512-oYWiJbWRQ7gz9Mj0X/NHFJ3OcLMOBzq/2b3j6zeNrQmtFo6dHwU8FAwNpxVIYddVMd+g8eqEi7iRueYx8FtM0Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5860,13 +6047,13 @@
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.19.1",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.19.1.tgz",
-      "integrity": "sha512-TRb8x9MuRrBYx7SjwW4hGnEMTnEPDk/jCQRjziS7AkPj0ahayqYlSjoZG3AWKc5NLOwulLekGbhQXUMRAdaA/A==",
+      "version": "13.29.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.29.0.tgz",
+      "integrity": "sha512-Az9gTLZpndmQouuKCzwrKmMrOUxqfWJf1KfEVF7y59RvAJlflCn3RZ5iajIZgo2FqoAmCBGIgd0sovWWSXBWtw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/python-analysis": "0.11.0",
+        "@vercel/python-analysis": "0.11.1",
         "cjs-module-lexer": "1.2.3",
         "es-module-lexer": "1.5.0"
       }
@@ -5879,19 +6066,70 @@
       "license": "MIT"
     },
     "node_modules/@vercel/cervel": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.0.54.tgz",
-      "integrity": "sha512-VHIfHr+5YaKdQAy/tatHlU0PnBzwEkHpWCje5f65gi0vd2Ti9d39jL/80q6PYeiFFlhExOrC7YfO87uHOLjsHg==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.18.tgz",
+      "integrity": "sha512-2ivMCEGj0GW6ewB57UnKVkHtR9o6z5l7r6FNf9spvxtJNR3zCv0ztsI8GnZgdrg5YxphLjjyQsUdPvOIPo9d2A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.1.2"
+        "@vercel/backends": "0.8.10"
       },
       "bin": {
         "cervel": "bin/cervel.mjs"
-      },
-      "peerDependencies": {
-        "typescript": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-auth": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-auth/-/cli-auth-0.3.0.tgz",
+      "integrity": "sha512-9nsdxUpV/L+9CBVGeRw/Qby2azhi2lk01jp0aTH+Hxx2U61+mAmbi5qChHnrbEmQdx2Ih7dp4LxO3nj1Q7f/5Q==",
+      "dev": true,
+      "dependencies": {
+        "@napi-rs/keyring": "1.2.0",
+        "@vercel/cli-config": "0.2.0",
+        "async-listen": "3.0.0",
+        "open": "8.4.0",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/async-listen": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
+      "integrity": "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@vercel/cli-auth/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@vercel/detect-agent": {
@@ -5905,34 +6143,34 @@
       }
     },
     "node_modules/@vercel/elysia": {
-      "version": "0.1.70",
-      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.70.tgz",
-      "integrity": "sha512-UJaXenUsn45b1hrMTs/zAl/OiXPuzj5UzoYXaLf/04rPqvRT6HU9qWYsBpQjtkJgYLg4HB+M1xhv1EKOz1EKWg==",
+      "version": "0.1.91",
+      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.91.tgz",
+      "integrity": "sha512-keZyTbfSGmCbOBOO2iO3cCLpwmwtwz7Or4NLovYvi1GKDE1UJ5Ye7YZqPncBw1TpQ5iIXH9nAmosWAgKmEFKXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
-        "@vercel/static-config": "3.2.0"
+        "@vercel/node": "5.8.15",
+        "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/error-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.0.3.tgz",
-      "integrity": "sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.2.0.tgz",
+      "integrity": "sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/express": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.80.tgz",
-      "integrity": "sha512-noHMleNoodWYlTNZE5hnC1m4Llt2KsK06/8aRM22kWVItmdRg9D63obTBTs14/N6IIrj0qyzt8YMvv4oHNg7XQ==",
+      "version": "0.1.101",
+      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.101.tgz",
+      "integrity": "sha512-FclC6t7L9LxMvnqS0AF3mZtGA5ikHpJeEi7dYAnt6ZVuiuGf3Gs+CZDGV9rioOTc2JcNVOcfZRkRWzEMgu6F5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/cervel": "0.0.54",
-        "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.7.12",
-        "@vercel/static-config": "3.2.0",
+        "@vercel/cervel": "0.1.18",
+        "@vercel/nft": "1.10.0",
+        "@vercel/node": "5.8.15",
+        "@vercel/static-config": "3.4.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
         "ts-morph": "12.0.0",
@@ -5950,14 +6188,14 @@
       }
     },
     "node_modules/@vercel/fastify": {
-      "version": "0.1.73",
-      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.73.tgz",
-      "integrity": "sha512-BGMg/KuTXQX0DHPgSNCMK7Msfcltdlc/H6NyxDOg6yVhw8ITOhv541YnDD4ogBEvqM1qDA1UPQqb47GfQJMvkw==",
+      "version": "0.1.94",
+      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.94.tgz",
+      "integrity": "sha512-NanNIsx2mOGEltPSYco2tMQTQD3B4KnK4csnIDLeJgBUCY7Kkh2pz7PLhEvcVC7l+3R4e+DsqrFX2kWaKMm1QQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
-        "@vercel/static-config": "3.2.0"
+        "@vercel/node": "5.8.15",
+        "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/fun": {
@@ -6086,14 +6324,14 @@
       }
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.1.20.tgz",
-      "integrity": "sha512-smLWjyPK/9dx0KzRktrqvTBDmA5198a7pju80xgt5DA9ffCwPqPNWfRCEHiCf+20eGtkqn+nlaeA5KBBl0NOVQ==",
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.17.tgz",
+      "integrity": "sha512-sGAG0qvZUerYokXoJRtAmrDtKCWMdEZdj1GVvfwaMijeSJari9FMKLMQ24v3STxGRVFRtv4t4dJgFZCRsDmv0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "13.19.1",
+        "@vercel/build-utils": "13.29.0",
         "esbuild": "0.27.0",
         "etag": "1.8.1",
         "fs-extra": "11.1.0"
@@ -6584,33 +6822,33 @@
       }
     },
     "node_modules/@vercel/go": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.5.0.tgz",
-      "integrity": "sha512-xMHQLqQiEfK+YJlC5eJ4S/1E4fBEUAf1u2DwQYsZlS3rLlHVqTOcZ973Z+wZV5pr4/d3vvpgB4/GQ0eqdig0jw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.8.0.tgz",
+      "integrity": "sha512-ftQqQMn3sGdL8mdIqfcS3YZg6dazM/h4s0jkY37oVV1rPdh7Aq/GL0oMjv1L+PoIk5uJEAyBan7C8Yisp4LH+g==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/h3": {
-      "version": "0.1.79",
-      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.79.tgz",
-      "integrity": "sha512-9dHqIr7qNA43GxPW+gWKu1H+jfNVb67w+a28x5bgc/Ienf5t9o618zNWT1w78C86nwHFlK1b/F/kj+LXFhcKuQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.100.tgz",
+      "integrity": "sha512-dv0QXzq1+gUGvfwTivl+Sv8sly+Qj0kPdV0XKotIf1IShoOHiR3xxd3FN4AmXXbSAf1WhUbvtr73JlMUcgvIHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
-        "@vercel/static-config": "3.2.0"
+        "@vercel/node": "5.8.15",
+        "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/hono": {
-      "version": "0.2.73",
-      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.73.tgz",
-      "integrity": "sha512-Lf9iPD1fOK2lv2PX2u5MQEID/FMQyK24qDZFyB56jzEaCWt7Qlihc2uCh2g/ONMPk7DlS4Gw/lHA9VkLP+VjKQ==",
+      "version": "0.2.94",
+      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.94.tgz",
+      "integrity": "sha512-UsCle8BxJoQnGRR2UmZyqEiTiodphAA8IOWd8zSNIRoVJFb/7xCmc1/q22Waek3lHXYZ+xBCUBuY/+NR/Z5KEg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/nft": "1.5.0",
-        "@vercel/node": "5.7.12",
-        "@vercel/static-config": "3.2.0",
+        "@vercel/nft": "1.10.0",
+        "@vercel/node": "5.8.15",
+        "@vercel/static-config": "3.4.0",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
         "ts-morph": "12.0.0",
@@ -6628,52 +6866,52 @@
       }
     },
     "node_modules/@vercel/hydrogen": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.3.6.tgz",
-      "integrity": "sha512-Ec8dKEjGIM4BfThcRLtQs5zaJ4+iJbgLZwkytwi7Blk8VrK6W2F1dtLDmVQYZdVnQcnmHmTx8mxUuMkfP06Mnw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.4.0.tgz",
+      "integrity": "sha512-gf3ELmAjcia7WNGNHAB/rFWFU0l5fJ7mTMgGC5hvcCjSIE4kp8WWuGYiTQgQ8W6GF/1FJAxa2J3BhY/yxjY8tA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/static-config": "3.2.0",
+        "@vercel/static-config": "3.4.0",
         "ts-morph": "12.0.0"
       }
     },
     "node_modules/@vercel/koa": {
-      "version": "0.1.53",
-      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.53.tgz",
-      "integrity": "sha512-vVIQ1zV9f73+Ltr7sWO+uFz6X8KWFT6v1ptjY0l9YE0OZWOY+NPRy0+6n/BFrlE9BWUuWq816Nv5EKqS88/TeQ==",
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.74.tgz",
+      "integrity": "sha512-XH2Y1Y1n73VgZvKKyctU8Hrm8XEIZEvPK4h55mACXNO/Zx4/iaDohUMipt1VDX5sm0098UVNRujUA/LeU2IdGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
-        "@vercel/static-config": "3.2.0"
+        "@vercel/node": "5.8.15",
+        "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/nestjs": {
-      "version": "0.2.74",
-      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.74.tgz",
-      "integrity": "sha512-mE1C+RFWpwtF7erTiwLuL32lnLBg+xlH57JgmSS0JKXKMTZAWKJgbKC/ya06O9ChXB5PYdSowjVvLk/oGqGj0A==",
+      "version": "0.2.95",
+      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.95.tgz",
+      "integrity": "sha512-O245Z3OKR4xtmfPO2rzfxxo4s5jRwGXteCl1Vyrw+JJ4Og0jKdQoI/Wcawm6L1qRw3UX8YtwA+zj2RykJ1kJ7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.7.12",
-        "@vercel/static-config": "3.2.0"
+        "@vercel/node": "5.8.15",
+        "@vercel/static-config": "3.4.0"
       }
     },
     "node_modules/@vercel/next": {
-      "version": "4.16.8",
-      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.16.8.tgz",
-      "integrity": "sha512-buiiOH7t8afdBHcF9vdIZ9z4LwA5hcTS9AUq6UlSY7qbKeeRUIgSVdz8QrYNvHhKMj/CAaTB92C/k25u9U9Muw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.18.0.tgz",
+      "integrity": "sha512-8H8/kCBfYjLLOSP16YaYndr1fZR4C0YC3tf9dQqSb8UgM+QB21I+mDntYU6YIZt0z8GcCizNk2AD0D64UjAyVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/nft": "1.5.0"
+        "@vercel/nft": "1.10.0"
       }
     },
     "node_modules/@vercel/nft": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.5.0.tgz",
-      "integrity": "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.10.0.tgz",
+      "integrity": "sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6728,9 +6966,9 @@
       }
     },
     "node_modules/@vercel/node": {
-      "version": "5.7.12",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.12.tgz",
-      "integrity": "sha512-ClU5ttdwMUr+IC43nNdRhHQR9XnIaF1SNUSJ0IrTQvqXt9ItLvS1zEDRF83VPLVFs4Rd6WtSB2kcGGsRzHjcEw==",
+      "version": "5.8.15",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.15.tgz",
+      "integrity": "sha512-arTGDg9/6qXxcFqpGeM8zCFLEoji69T/d2GQS/GYbM2Zx9pnzXQCHwY/sMnB5QSmoWVPDVHRSUmno//G7npDOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6738,10 +6976,10 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.19.1",
-        "@vercel/error-utils": "2.0.3",
-        "@vercel/nft": "1.5.0",
-        "@vercel/static-config": "3.2.0",
+        "@vercel/build-utils": "13.29.0",
+        "@vercel/error-utils": "2.2.0",
+        "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.0",
         "async-listen": "3.0.0",
         "cjs-module-lexer": "1.2.3",
         "edge-runtime": "2.5.9",
@@ -7328,26 +7566,26 @@
       }
     },
     "node_modules/@vercel/prepare-flags-definitions": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@vercel/prepare-flags-definitions/-/prepare-flags-definitions-0.2.1.tgz",
-      "integrity": "sha512-ouXTsqn7I9xZ1KKezgvn/w3tZeQHL/tc52j9GHiOYi6kT8xgdbT8s2x8C9BQr44iceX0hfhtZwk9q7NuI2Tqbw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@vercel/prepare-flags-definitions/-/prepare-flags-definitions-0.3.0.tgz",
+      "integrity": "sha512-/0nuDFwYje0nqZnVKSd2VfJy2wOPQwbkas1qO1JQgtb0sLl+EeSCW4O9hrvq55pN50PNlAZ/APSeWHIAT9ZGHg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vercel/python": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.35.0.tgz",
-      "integrity": "sha512-BpJ0+jrufofKQqt2lK7zIW4/ll3b4H8hzMnX7cchE1jbTIyywpIUdr4c9hCxLIfjw6j+NWx2Kew6kisRFyzHxQ==",
+      "version": "6.44.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.44.0.tgz",
+      "integrity": "sha512-78+todx9665oQSZahIsK8o6gN76oKyPeuw5g61ZI88sAjHgjXL0qE5ou+rEBjwTfRa5+hXxBeeWi7YUpCQ8xJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/python-analysis": "0.11.0"
+        "@vercel/python-analysis": "0.11.1"
       }
     },
     "node_modules/@vercel/python-analysis": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.11.0.tgz",
-      "integrity": "sha512-gsoj+nscmNm0xDh+tRhECRhit2VlAVaD7jc9h93sN6rDEBDxPo7eLEgIJFzVDaAItxERZ9Od2IK/04fB9vFy+g==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.11.1.tgz",
+      "integrity": "sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7402,28 +7640,28 @@
       }
     },
     "node_modules/@vercel/redwood": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.4.12.tgz",
-      "integrity": "sha512-8kJ7eEerI4iMpKVRxQCsnxiIwRVsWtyirEbYb4erCqqsJymTu/xrjhsfAUuzeP8qkuYGP82MJVK+hpKlFtsjGw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.5.0.tgz",
+      "integrity": "sha512-LO24CbieV57rGAqrq5n5z/B+fMYeUqbE/Ge3qMeKRuS3Q9awgcBgB6WYLCe8crHM7XJd5AZjbuyoS/6k3r0X0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/nft": "1.5.0",
-        "@vercel/static-config": "3.2.0",
+        "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.0",
         "semver": "6.3.1",
         "ts-morph": "12.0.0"
       }
     },
     "node_modules/@vercel/remix-builder": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-5.7.2.tgz",
-      "integrity": "sha512-bfStsDBQramYbWugelfyp1szTuDOLQ+ZELvgA9cpYc4FucgCrDy/bpvMMvsjiDACB9PoDzLrG//ZBgsic9yAhg==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-5.9.0.tgz",
+      "integrity": "sha512-D3T8txLxp6lVECs+P0tQxsH7AmNZiwlZXjRwWszv4mtNrWrXEPEGLEJShBzvibi2r5O9RlUCJ8bWEVlm8+ILNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/error-utils": "2.0.3",
-        "@vercel/nft": "1.5.0",
-        "@vercel/static-config": "3.2.0",
+        "@vercel/error-utils": "2.2.0",
+        "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.0",
         "path-to-regexp": "6.1.0",
         "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
         "ts-morph": "12.0.0"
@@ -7437,16 +7675,16 @@
       "license": "MIT"
     },
     "node_modules/@vercel/ruby": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.3.2.tgz",
-      "integrity": "sha512-okIgMmPEePyDR9TZYaKM4oftcxVHM5Dbdl7V/tIdh3lq8MGLi7HR5vvQglmZUwZOeovE6MVtezxl960EOzeIiQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.4.0.tgz",
+      "integrity": "sha512-YI7Amyf09hHZWOqDHgJO92XcKh6Pye8rrmJFhlP6euG3o6QjoZzJj7Z2WzjSrDRGMewzEK4uz2+CbNpNS7gLog==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/rust": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.1.1.tgz",
-      "integrity": "sha512-y6GYEQ8ltRRD8JNmSt0kWars7IMKjm1Nv26rFgl9wWVFqe5UeAvAHohiTX7D6W0Yowx6v+BnR3czeoVHwQvEMg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.3.0.tgz",
+      "integrity": "sha512-z1X0z1NM+ISunm/scgRpuENNwcKlh7DjXn0QvKE0n10DcaYqxkBQVK8iRA9X05xSK9AzPlnB9DHdGKiXZO5buw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7509,27 +7747,39 @@
       "license": "ISC"
     },
     "node_modules/@vercel/sandbox": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-1.9.0.tgz",
-      "integrity": "sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.1.1.tgz",
+      "integrity": "sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/oidc": "3.2.0",
+        "@workflow/serde": "4.1.0-beta.2",
         "async-retry": "1.3.3",
+        "jose": "6.2.3",
         "jsonlines": "0.1.1",
         "ms": "2.1.3",
         "picocolors": "^1.1.1",
         "tar-stream": "3.1.7",
-        "undici": "^7.16.0",
+        "undici": "^7.27.1",
         "xdg-app-paths": "5.1.0",
         "zod": "3.24.4"
       }
     },
+    "node_modules/@vercel/sandbox/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@vercel/sandbox/node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7547,22 +7797,22 @@
       }
     },
     "node_modules/@vercel/static-build": {
-      "version": "2.9.20",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.9.20.tgz",
-      "integrity": "sha512-jE0aG9GswRUwXor2CJunUP15Au5XJEpmbwLlnDhOUruMvjVA3nyAmbHGznzBn0n+PjhopXwehiyFazIJUwKWdg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.10.1.tgz",
+      "integrity": "sha512-qMXFgMY+/NtecAmNxpxPJ7F8AG9b3WeScQBsvq3Ay6zUsy3buz+qnzo/0po+YdFr/t0/WIBsAuL/O7cCoREXhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-        "@vercel/gatsby-plugin-vercel-builder": "2.1.20",
-        "@vercel/static-config": "3.2.0",
+        "@vercel/gatsby-plugin-vercel-builder": "2.2.17",
+        "@vercel/static-config": "3.4.0",
         "ts-morph": "12.0.0"
       }
     },
     "node_modules/@vercel/static-config": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.2.0.tgz",
-      "integrity": "sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.4.0.tgz",
+      "integrity": "sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7708,43 +7958,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@yarnpkg/parsers": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.3.tgz",
-      "integrity": "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==",
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "js-yaml": "^3.10.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
+      "license": "Apache-2.0"
     },
     "node_modules/abbrev": {
       "version": "3.0.1",
@@ -7762,6 +7981,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7837,6 +8057,18 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/arg": {
@@ -8131,9 +8363,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -8163,9 +8395,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -8190,9 +8422,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8259,6 +8491,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8757,6 +8990,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -9239,6 +9482,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9424,6 +9668,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9832,9 +10077,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -9843,13 +10088,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -9858,9 +10104,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -10116,6 +10363,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -10234,9 +10494,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10653,9 +10913,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10842,6 +11102,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -11142,6 +11418,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -11273,9 +11562,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12790,6 +13079,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -13037,9 +13344,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -13318,6 +13625,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13327,6 +13635,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13669,13 +13978,14 @@
       "license": "MIT"
     },
     "node_modules/sandbox": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-2.5.6.tgz",
-      "integrity": "sha512-tnFr7nyiuEhsAGb+xy60SDbij0790X+FgDljh3J/2HaRM6yQgNJkQKHbDH8ld7mR+PozXGgEfJ2Dc/5OyFnwsg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-3.1.2.tgz",
+      "integrity": "sha512-g93rma0Z9Aa6EoTktzYnGZmQvMzm7j73BekJIMwmkdWR5uryZ+6hBCADtd3JKGAB27k+ubnG7HHsZqtscAMzIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/sandbox": "1.9.0",
+        "@vercel/sandbox": "2.1.1",
+        "async-retry": "1.3.3",
         "debug": "^4.4.1",
         "zod": "^4.1.1"
       },
@@ -14147,9 +14457,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14328,16 +14638,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -14392,7 +14705,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -14545,6 +14859,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14802,6 +15117,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14861,9 +15177,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15067,43 +15383,46 @@
       "license": "MIT"
     },
     "node_modules/vercel": {
-      "version": "51.8.0",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-51.8.0.tgz",
-      "integrity": "sha512-0NVtnfF/7y2b/lEh3MFDpsaSkxdTQEbs58ORJT2orixPDyu67tq/6THvds269JguMWpQui4h7BedYunZXy7d3A==",
+      "version": "54.11.1",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-54.11.1.tgz",
+      "integrity": "sha512-4KRwPLjrcdCQEa2AvSUuucrKePmspLa6Ahlmu7f8A836hA1mj3O+YDwgvytriQsQXVAHoqKWUO6ovdIN2+GGrA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.1.2",
-        "@vercel/blob": "2.3.0",
-        "@vercel/build-utils": "13.19.1",
+        "@vercel/backends": "0.8.10",
+        "@vercel/blob": "2.4.0",
+        "@vercel/build-utils": "13.29.0",
+        "@vercel/cli-auth": "0.3.0",
+        "@vercel/cli-config": "0.2.0",
         "@vercel/detect-agent": "1.2.3",
-        "@vercel/elysia": "0.1.70",
-        "@vercel/express": "0.1.80",
-        "@vercel/fastify": "0.1.73",
+        "@vercel/elysia": "0.1.91",
+        "@vercel/express": "0.1.101",
+        "@vercel/fastify": "0.1.94",
         "@vercel/fun": "1.3.0",
-        "@vercel/go": "3.5.0",
-        "@vercel/h3": "0.1.79",
-        "@vercel/hono": "0.2.73",
-        "@vercel/hydrogen": "1.3.6",
-        "@vercel/koa": "0.1.53",
-        "@vercel/nestjs": "0.2.74",
-        "@vercel/next": "4.16.8",
-        "@vercel/node": "5.7.12",
-        "@vercel/prepare-flags-definitions": "0.2.1",
-        "@vercel/python": "6.35.0",
-        "@vercel/redwood": "2.4.12",
-        "@vercel/remix-builder": "5.7.2",
-        "@vercel/ruby": "2.3.2",
-        "@vercel/rust": "1.1.1",
-        "@vercel/static-build": "2.9.20",
+        "@vercel/go": "3.8.0",
+        "@vercel/h3": "0.1.100",
+        "@vercel/hono": "0.2.94",
+        "@vercel/hydrogen": "1.4.0",
+        "@vercel/koa": "0.1.74",
+        "@vercel/nestjs": "0.2.95",
+        "@vercel/next": "4.18.0",
+        "@vercel/node": "5.8.15",
+        "@vercel/prepare-flags-definitions": "0.3.0",
+        "@vercel/python": "6.44.0",
+        "@vercel/redwood": "2.5.0",
+        "@vercel/remix-builder": "5.9.0",
+        "@vercel/ruby": "2.4.0",
+        "@vercel/rust": "1.3.0",
+        "@vercel/static-build": "2.10.1",
         "chokidar": "4.0.0",
         "esbuild": "0.27.0",
         "form-data": "^4.0.0",
         "jose": "5.9.6",
         "luxon": "^3.4.0",
         "proxy-agent": "6.4.0",
-        "sandbox": "2.5.6",
-        "smol-toml": "1.5.2"
+        "sandbox": "3.1.2",
+        "smol-toml": "1.5.2",
+        "zod": "4.1.11"
       },
       "bin": {
         "vc": "dist/vc.js",
@@ -15597,6 +15916,16 @@
         "@esbuild/win32-x64": "0.27.0"
       }
     },
+    "node_modules/vercel/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -15631,6 +15960,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16009,6 +16339,21 @@
         "node": ">= 6.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -16072,6 +16417,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "19.2.4",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
+    "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -35,7 +36,7 @@
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",
-    "vercel": "^51.8.0",
+    "vercel": "^54.11.1",
     "vitest": "^4.1.4"
   }
 }

--- a/registry.json.example
+++ b/registry.json.example
@@ -2,6 +2,7 @@
   "endpoint": "https://your-cloudflare-account-id.r2.cloudflarestorage.com",
   "accessKeyId": "your-r2-access-key-id",
   "secretAccessKey": "your-r2-secret-access-key",
+  "thumbnailSizes": [320, 640, 960, 1280],
   "sites": [
     {
       "domain": "example.com",
@@ -9,7 +10,8 @@
       "vaultPath": "/absolute/path/to/your/obsidian/vault",
       "bucketName": "your-r2-bucket-name",
       "vercelProjectId": "your-vercel-project-id",
-      "endpoint": "https://your-custom-s3-endpoint.com"
+      "endpoint": "https://your-custom-s3-endpoint.com",
+      "thumbnailSizes": [400, 800, 1200]
     }
   ]
 }

--- a/registry.json.example
+++ b/registry.json.example
@@ -2,6 +2,7 @@
   "endpoint": "https://your-cloudflare-account-id.r2.cloudflarestorage.com",
   "accessKeyId": "your-r2-access-key-id",
   "secretAccessKey": "your-r2-secret-access-key",
+  "imageHost": "https://img.your-global-domain.com",
   "thumbnailSizes": [320, 640, 960, 1280],
   "sites": [
     {
@@ -11,7 +12,13 @@
       "bucketName": "your-r2-bucket-name",
       "vercelProjectId": "your-vercel-project-id",
       "endpoint": "https://your-custom-s3-endpoint.com",
-      "thumbnailSizes": [400, 800, 1200]
+      "imageHost": "https://img.your-global-domain.com",
+      "thumbnailSizes": [400, 800, 1200],
+      "wordpress": {
+        "username": "your-wp-username",
+        "applicationPassword": "xxxx xxxx xxxx xxxx xxxx xxxx",
+        "endpoint": "https://your-wordpress-site.com/wp-json"
+      }
     }
   ]
 }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -12,6 +12,7 @@ import { normalizeThumbnailSizes } from '../src/lib/responsive-images';
 import { exists } from './lib/files';
 import { generateIndices } from './lib/indices';
 import { generateSitemaps } from './lib/sitemaps';
+import { pushToWordPress } from './lib/wordpress';
 
 type CommandResult = {
   status: number | null;
@@ -416,6 +417,8 @@ async function syncContent({
   if (!isDryRun) {
     await uploadRegistry({ site, registry });
   }
+
+  return { allIndices };
 }
 
 function getRunMode(): RunMode {
@@ -450,7 +453,21 @@ async function main() {
       return;
     }
 
-    await syncContent({ site, registry, isDryRun });
+    const shouldPushWp = hasFlag({ flag: '--wp' });
+    const targetPostSlug = getFlagValue({ flag: '--post' });
+    
+    const { allIndices } = await syncContent({ site, registry, isDryRun });
+
+    if (shouldPushWp) {
+      await pushToWordPress({
+        site,
+        registry,
+        allIndices,
+        targetPostSlug,
+        dryRun: isDryRun,
+      });
+    }
+
     if (isDryRun) {
       console.log('\n✅ Dry run completed successfully!');
       return;

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,18 +1,17 @@
 import { select } from '@inquirer/prompts';
-import matter from 'gray-matter';
-import { z } from 'zod';
-import { readFile, writeFile, readdir, stat, unlink, access, mkdir } from 'fs/promises';
-import { constants } from 'fs';
+import { readFile, writeFile, unlink } from 'fs/promises';
 import { spawn, SpawnOptions } from 'child_process';
-import { join, relative } from 'path';
+import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import { getRegistry } from '../src/lib/registry';
 import { env, ENV_KEYS, ENV_METADATA } from '../src/lib/env';
-import { INDEX_JSON, ROOT_JSON, INDEX_SLUG, SITEMAP_XML, SITEMAP_PAGES_XML } from '../src/lib/constants';
-import { PageMetadata, VaultDirectoryIndex, VaultRootIndex } from '../src/lib/vault';
 import { hasFlag, getFlagValue } from '../src/lib/cli';
 import { Registry, Site } from '../src/domain/registry';
+import { normalizeThumbnailSizes } from '../src/lib/responsive-images';
+import { exists } from './lib/files';
+import { generateIndices } from './lib/indices';
+import { generateSitemaps } from './lib/sitemaps';
 
 type CommandResult = {
   status: number | null;
@@ -28,15 +27,6 @@ type SpawnWithInputOptions = SpawnOptions & {
 type RunMode = 'sync' | 'deploy' | 'configure';
 
 const VERCEL_CONFIG_PATH = 'vercel.json';
-
-async function exists(path: string) {
-  try {
-    await access(path, constants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 async function execAsync({
   command,
@@ -91,274 +81,6 @@ function spawnWithInput({
       resolve({ status: null, signal: null, error, stderr });
     });
   });
-}
-
-const DateInputSchema = z.union([z.string(), z.number(), z.date()]);
-
-function parseSafeDate({
-  dateInput,
-  fallback,
-  label,
-  filePath,
-}: {
-  dateInput: unknown;
-  fallback: Date;
-  label: string;
-  filePath: string;
-}): string {
-  if (!dateInput) return fallback.toISOString();
-
-  const result = DateInputSchema.safeParse(dateInput);
-  if (!result.success) {
-    console.warn(
-      `⚠️  Warning: Invalid ${label} type for "${dateInput}" in ${filePath}. Falling back to file modification time.`
-    );
-    return fallback.toISOString();
-  }
-
-  const date = new Date(result.data);
-  if (isNaN(date.getTime())) {
-    console.warn(
-      `⚠️  Warning: Invalid ${label} value "${dateInput}" in ${filePath}. Falling back to file modification time.`
-    );
-    return fallback.toISOString();
-  }
-
-  return date.toISOString();
-}
-
-function escapeXml(unsafe: string): string {
-  const map: Record<string, string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&apos;',
-  };
-  return unsafe.replace(/[&<>"']/g, (m) => map[m]);
-}
-
-function generateSitemapXml(urls: { loc: string; lastmod?: string }[]): string {
-  const urlTags = urls
-    .map(
-      (url) => `  <url>
-    <loc>${escapeXml(url.loc)}</loc>${url.lastmod ? `\n    <lastmod>${url.lastmod}</lastmod>` : ''}
-  </url>`
-    )
-    .join('\n');
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urlTags}
-</urlset>`;
-}
-
-function generateSitemapIndexXml(sitemaps: { loc: string; lastmod?: string }[]): string {
-  const sitemapTags = sitemaps
-    .map(
-      (sitemap) => `  <sitemap>
-    <loc>${escapeXml(sitemap.loc)}</loc>${sitemap.lastmod ? `\n    <lastmod>${sitemap.lastmod}</lastmod>` : ''}
-  </sitemap>`
-    )
-    .join('\n');
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${sitemapTags}
-</sitemapindex>`;
-}
-
-function mapPagesToSitemapUrls({
-  pages,
-  domain,
-  relDir = '',
-}: {
-  pages: PageMetadata[];
-  domain: string;
-  relDir?: string;
-}) {
-  return pages.map((p) => {
-    const urlPath = p.slug === INDEX_SLUG ? relDir : relDir ? `${relDir}/${p.slug}` : p.slug;
-    return {
-      loc: `https://${domain}/${urlPath}`,
-      lastmod: p.updatedAt || p.date,
-    };
-  });
-}
-
-async function writeSitemapFile({
-  fullPath,
-  relPath,
-  content,
-  dryRun,
-  label,
-}: {
-  fullPath: string;
-  relPath: string;
-  content: string;
-  dryRun: boolean;
-  label: string;
-}) {
-  if (!dryRun) {
-    const dir = join(fullPath, '..');
-    await mkdir(dir, { recursive: true });
-    await writeFile(fullPath, content);
-    console.log(`✨ Generated ${label} at ${relPath}`);
-  } else {
-    console.log(`[DRY RUN] Would generate ${label} at ${relPath}`);
-  }
-}
-
-async function scanPublicFiles({ dir, baseDir = dir }: { dir: string; baseDir?: string }): Promise<string[]> {
-  const files: string[] = [];
-
-  async function walk(currentDir: string) {
-    if (!(await exists(currentDir))) return;
-    const entries = await readdir(currentDir, { withFileTypes: true });
-
-    for (const entry of entries) {
-      const fullPath = join(currentDir, entry.name);
-
-      if (entry.isDirectory()) {
-        if (entry.name !== '.git' && entry.name !== 'node_modules') {
-          await walk(fullPath);
-        }
-      } else if (entry.isFile()) {
-        const relPath = relative(baseDir, fullPath);
-        files.push(relPath.replace(/\\/g, '/'));
-      }
-    }
-  }
-
-  await walk(dir);
-  return files;
-}
-
-async function generateAllSitemaps({
-  domain,
-  allIndices,
-  vaultPath,
-  dryRun,
-}: {
-  domain: string;
-  allIndices: Map<string, VaultDirectoryIndex>;
-  vaultPath: string;
-  dryRun: boolean;
-}): Promise<string[]> {
-  const subSitemaps: string[] = [];
-  for (const [relDir, indexData] of allIndices.entries()) {
-    if (relDir === '') continue; // Skip root, handled separately
-    if (indexData.pages.length === 0) continue;
-
-    const sitemapUrls = mapPagesToSitemapUrls({ pages: indexData.pages, domain, relDir });
-    const sitemapContent = generateSitemapXml(sitemapUrls);
-    const sitemapPath = join(vaultPath, 'public', relDir, SITEMAP_XML);
-    const relSitemapPath = `public/${relDir}/${SITEMAP_XML}`;
-
-    await writeSitemapFile({
-      fullPath: sitemapPath,
-      relPath: relSitemapPath,
-      content: sitemapContent,
-      dryRun,
-      label: `sitemap for "${relDir}"`,
-    });
-    subSitemaps.push(`${relDir}/${SITEMAP_XML}`);
-  }
-  return subSitemaps;
-}
-
-async function scanAndGenerate({
-  dir,
-  baseDir,
-  dryRun,
-  allIndices,
-}: {
-  dir: string;
-  baseDir: string;
-  dryRun: boolean;
-  allIndices: Map<string, VaultDirectoryIndex>;
-}): Promise<{ index: VaultDirectoryIndex; allDirs: string[] }> {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const pages: PageMetadata[] = [];
-  let allDirs: string[] = [];
-
-  const relDir = relative(baseDir, dir).replace(/\\/g, '/');
-
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-
-    if (entry.isDirectory()) {
-      if (entry.name !== '.git' && entry.name !== 'node_modules') {
-        const result = await scanAndGenerate({ dir: fullPath, baseDir, dryRun, allIndices });
-
-        const childRelDir = relative(baseDir, fullPath).replace(/\\/g, '/');
-        allDirs.push(childRelDir, ...result.allDirs);
-      }
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
-      const fileContent = await readFile(fullPath, 'utf-8');
-      const fileStats = await stat(fullPath);
-
-      const { data, content } = matter(fileContent);
-
-      if (data.published === false) {
-        continue;
-      }
-
-      const titleMatch = content.match(/^#\s+(.+)$/m);
-      const title =
-        typeof data.title === 'string' && data.title.trim() !== ''
-          ? data.title
-          : titleMatch
-          ? titleMatch[1].trim()
-          : entry.name;
-
-      const relPath = relative(baseDir, fullPath).replace(/\\/g, '/');
-      const slug = relative(dir, fullPath).replace(/\.md$/, '').replace(/\\/g, '/');
-
-      const date = parseSafeDate({ dateInput: data.date, fallback: fileStats.mtime, label: 'date', filePath: relPath });
-      const manualUpdate = data.updated || data.lastmod;
-      const updatedAt = parseSafeDate({
-        dateInput: manualUpdate,
-        fallback: fileStats.mtime,
-        label: 'updated',
-        filePath: relPath,
-      });
-
-      const firstParagraph = content
-        .split('\n')
-        .map((line) => line.trim())
-        .filter((line) => line && !line.startsWith('#') && !line.startsWith('>'))[0];
-
-      let excerpt = '';
-      if (firstParagraph) {
-        excerpt = firstParagraph.slice(0, 160);
-        if (firstParagraph.length > 160) {
-          excerpt += '...';
-        }
-      }
-
-      pages.push({ title, slug, date, updatedAt, excerpt });
-    }
-  }
-
-  pages.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-
-  const indexData: VaultDirectoryIndex = {
-    version: 1,
-    pages,
-  };
-
-  const indexPath = join(dir, INDEX_JSON);
-  const relDirName = relDir || 'root';
-
-  if (!dryRun) {
-    await writeFile(indexPath, JSON.stringify(indexData, null, 2));
-    console.log(`✨ Generated index for "${relDirName}"`);
-  }
-
-  allIndices.set(relDir, indexData);
-
-  return { index: indexData, allDirs };
 }
 
 async function selectSite({
@@ -527,125 +249,6 @@ async function uploadRegistry({ site, registry }: { site: Site; registry: Regist
   }
 }
 
-async function generateIndices({
-  vaultPath,
-  dryRun = false,
-}: {
-  vaultPath: string;
-  dryRun?: boolean;
-}): Promise<{ rootContentIndex: VaultDirectoryIndex; allIndices: Map<string, VaultDirectoryIndex> }> {
-  const contentDir = join(vaultPath, 'content');
-  if (!(await exists(contentDir))) {
-    console.error(`⨯ Error: The required "content" directory is missing in the vault: ${vaultPath}`);
-    process.exit(1);
-  }
-
-  // 1. Recursive generation of index.json for each level in content/
-  console.log(`\n🔍 Recursively scanning "content" directory in ${contentDir}...`);
-  const allIndices = new Map<string, VaultDirectoryIndex>();
-  const { index: rootContentIndex, allDirs } = await scanAndGenerate({
-    dir: contentDir,
-    baseDir: contentDir,
-    dryRun,
-    allIndices,
-  });
-
-  const publicBaseDir = join(vaultPath, 'public');
-  if (!dryRun) {
-    await mkdir(publicBaseDir, { recursive: true });
-  }
-
-  const publicFiles = (await exists(publicBaseDir)) ? await scanPublicFiles({ dir: publicBaseDir }) : [];
-
-  // 2. Generate root.json at vault root pointing to top-level content
-  const rootPath = join(vaultPath, ROOT_JSON);
-  const vaultRootIndex: VaultRootIndex = {
-    ...rootContentIndex,
-    directories: allDirs, // root.json contains the full directory map
-    publicFiles,
-  };
-
-  if (dryRun) {
-    console.log(`[DRY RUN] Would generate master root index at: ${rootPath}`);
-  } else {
-    await writeFile(rootPath, JSON.stringify(vaultRootIndex, null, 2));
-    console.log(`✨ Generated master root index with ${allDirs.length} directories at: ${rootPath}`);
-  }
-
-  return { rootContentIndex, allIndices };
-}
-
-async function generateSitemaps({
-  vaultPath,
-  domain,
-  rootContentIndex,
-  allIndices,
-  dryRun,
-}: {
-  vaultPath: string;
-  domain: string | undefined;
-  rootContentIndex: VaultDirectoryIndex;
-  allIndices: Map<string, VaultDirectoryIndex>;
-  dryRun: boolean;
-}) {
-  if (!domain) {
-    console.log('ℹ️  Skipping sitemap generation because "domain" is not configured in registry.json');
-    return;
-  }
-
-  const publicBaseDir = join(vaultPath, 'public');
-  const subSitemaps = await generateAllSitemaps({ domain, allIndices, vaultPath, dryRun });
-  const rootPages = rootContentIndex.pages;
-  const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls({ pages: rootPages, domain }) : [];
-
-  if (subSitemaps.length === 0) {
-    // Case 1: No sub-sitemaps, write root pages to sitemap.xml directly
-    if (sitemapUrls.length > 0) {
-      const sitemapContent = generateSitemapXml(sitemapUrls);
-      const sitemapPath = join(publicBaseDir, SITEMAP_XML);
-      await writeSitemapFile({
-        fullPath: sitemapPath,
-        relPath: `public/${SITEMAP_XML}`,
-        content: sitemapContent,
-        dryRun,
-        label: 'sitemap',
-      });
-    }
-  } else {
-    // Case 2: Sub-sitemaps exist, sitemap.xml should be an index
-    const sitemaps = [];
-
-    if (sitemapUrls.length > 0) {
-      const sitemapContent = generateSitemapXml(sitemapUrls);
-      const sitemapPath = join(publicBaseDir, SITEMAP_PAGES_XML);
-      await writeSitemapFile({
-        fullPath: sitemapPath,
-        relPath: `public/${SITEMAP_PAGES_XML}`,
-        content: sitemapContent,
-        dryRun,
-        label: 'root pages sitemap',
-      });
-      sitemaps.push({ loc: `https://${domain}/${SITEMAP_PAGES_XML}` });
-    }
-
-    for (const subSitemap of subSitemaps) {
-      sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
-    }
-
-    if (sitemaps.length > 0) {
-      const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
-      const sitemapIndexPath = join(publicBaseDir, SITEMAP_XML);
-      await writeSitemapFile({
-        fullPath: sitemapIndexPath,
-        relPath: `public/${SITEMAP_XML}`,
-        content: sitemapIndexContent,
-        dryRun,
-        label: 'master sitemap index',
-      });
-    }
-  }
-}
-
 function getVercelProjectId({ site }: { site: Site }): string {
   return site.vercelProjectId || site.siteId;
 }
@@ -793,7 +396,12 @@ async function syncContent({
   registry: Registry;
   isDryRun: boolean;
 }) {
-  const { rootContentIndex, allIndices } = await generateIndices({ vaultPath: site.vaultPath, dryRun: isDryRun });
+  const thumbnailSizes = normalizeThumbnailSizes(site.thumbnailSizes || registry.thumbnailSizes);
+  const { rootContentIndex, allIndices } = await generateIndices({
+    vaultPath: site.vaultPath,
+    thumbnailSizes,
+    dryRun: isDryRun,
+  });
 
   await generateSitemaps({
     vaultPath: site.vaultPath,

--- a/scripts/lib/files.test.ts
+++ b/scripts/lib/files.test.ts
@@ -48,4 +48,38 @@ describe('createFileScanner', () => {
 
     await expect(scanner.scanContentAssetFiles({ dir: 'content' })).resolves.toEqual(['image.png']);
   });
+
+  describe('getAssetSubDir', () => {
+    it('returns public if file exists in public sub-folder', async () => {
+      const scanner = createFileScanner({
+        access: vi.fn(async (filePath: string) => {
+          if (filePath !== 'root/public/images/pic.png') throw new Error('missing');
+        }),
+        readdir: vi.fn(),
+        fileOkMode: 0,
+        joinPath: path.posix.join,
+        relativePath: path.posix.relative,
+      });
+
+      await expect(
+        scanner.getAssetSubDir({ vaultPath: 'root', filePath: 'images/pic.png' })
+      ).resolves.toBe('public');
+    });
+
+    it('returns content if file does not exist in public sub-folder', async () => {
+      const scanner = createFileScanner({
+        access: vi.fn(async () => {
+          throw new Error('missing');
+        }),
+        readdir: vi.fn(),
+        fileOkMode: 0,
+        joinPath: path.posix.join,
+        relativePath: path.posix.relative,
+      });
+
+      await expect(
+        scanner.getAssetSubDir({ vaultPath: 'root', filePath: 'images/pic.png' })
+      ).resolves.toBe('content');
+    });
+  });
 });

--- a/scripts/lib/files.test.ts
+++ b/scripts/lib/files.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { createFileScanner, type FileEntry } from './files';
+
+function file(name: string): FileEntry {
+  return { name, isDirectory: () => false, isFile: () => true };
+}
+
+function directory(name: string): FileEntry {
+  return { name, isDirectory: () => true, isFile: () => false };
+}
+
+describe('createFileScanner', () => {
+  it('scans public files recursively while skipping ignored directories', async () => {
+    const tree: Record<string, FileEntry[]> = {
+      root: [file('logo.png'), directory('assets'), directory('node_modules')],
+      'root/assets': [file('photo.jpg')],
+      'root/node_modules': [file('ignored.js')],
+    };
+
+    const scanner = createFileScanner({
+      access: vi.fn(async (filePath: string) => {
+        if (!tree[filePath]) throw new Error('missing');
+      }),
+      readdir: vi.fn(async (filePath: string) => tree[filePath] || []),
+      fileOkMode: 0,
+      joinPath: path.posix.join,
+      relativePath: path.posix.relative,
+    });
+
+    await expect(scanner.scanPublicFiles({ dir: 'root' })).resolves.toEqual(['logo.png', 'assets/photo.jpg']);
+  });
+
+  it('excludes markdown and json files from content assets', async () => {
+    const tree: Record<string, FileEntry[]> = {
+      content: [file('page.md'), file('data.json'), file('image.png')],
+    };
+
+    const scanner = createFileScanner({
+      access: vi.fn(async (filePath: string) => {
+        if (!tree[filePath]) throw new Error('missing');
+      }),
+      readdir: vi.fn(async (filePath: string) => tree[filePath] || []),
+      fileOkMode: 0,
+      joinPath: path.posix.join,
+      relativePath: path.posix.relative,
+    });
+
+    await expect(scanner.scanContentAssetFiles({ dir: 'content' })).resolves.toEqual(['image.png']);
+  });
+});

--- a/scripts/lib/files.ts
+++ b/scripts/lib/files.ts
@@ -1,0 +1,91 @@
+import { access, readdir } from 'fs/promises';
+import { constants } from 'fs';
+import path from 'path';
+
+export type FileEntry = {
+  name: string;
+  isDirectory: () => boolean;
+  isFile: () => boolean;
+};
+
+export type FileScannerDeps = {
+  access: (path: string, mode?: number) => Promise<void>;
+  readdir: (path: string, options: { withFileTypes: true }) => Promise<FileEntry[]>;
+  fileOkMode: number;
+  joinPath: (...paths: string[]) => string;
+  relativePath: (from: string, to: string) => string;
+};
+
+export function createFileScanner(deps: FileScannerDeps) {
+  async function exists(filePath: string) {
+    try {
+      await deps.access(filePath, deps.fileOkMode);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function scanFiles({
+    dir,
+    baseDir = dir,
+    shouldIncludeFile,
+  }: {
+    dir: string;
+    baseDir?: string;
+    shouldIncludeFile: (name: string) => boolean;
+  }): Promise<string[]> {
+    const files: string[] = [];
+
+    async function walk(currentDir: string) {
+      if (!(await exists(currentDir))) return;
+      const entries = await deps.readdir(currentDir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = deps.joinPath(currentDir, entry.name);
+
+        if (entry.isDirectory()) {
+          if (entry.name !== '.git' && entry.name !== 'node_modules') {
+            await walk(fullPath);
+          }
+        } else if (entry.isFile() && shouldIncludeFile(entry.name)) {
+          const relPath = deps.relativePath(baseDir, fullPath);
+          files.push(relPath.replace(/\\/g, '/'));
+        }
+      }
+    }
+
+    await walk(dir);
+    return files;
+  }
+
+  return {
+    exists,
+    scanPublicFiles({ dir, baseDir = dir }: { dir: string; baseDir?: string }) {
+      return scanFiles({
+        dir,
+        baseDir,
+        shouldIncludeFile: () => true,
+      });
+    },
+    scanContentAssetFiles({ dir, baseDir = dir }: { dir: string; baseDir?: string }) {
+      return scanFiles({
+        dir,
+        baseDir,
+        shouldIncludeFile: (name) => !name.endsWith('.md') && !name.endsWith('.json'),
+      });
+    },
+  };
+}
+
+const defaultFileScanner = createFileScanner({
+  access,
+  readdir,
+  fileOkMode: constants.F_OK,
+  joinPath: path.join,
+  relativePath: path.relative,
+});
+
+export const exists = defaultFileScanner.exists;
+export const scanPublicFiles = defaultFileScanner.scanPublicFiles;
+export const scanContentAssetFiles = defaultFileScanner.scanContentAssetFiles;

--- a/scripts/lib/files.ts
+++ b/scripts/lib/files.ts
@@ -75,6 +75,19 @@ export function createFileScanner(deps: FileScannerDeps) {
         shouldIncludeFile: (name) => !name.endsWith('.md') && !name.endsWith('.json'),
       });
     },
+    async getAssetSubDir({
+      vaultPath,
+      filePath,
+    }: {
+      vaultPath: string;
+      filePath: string;
+    }): Promise<'public' | 'content'> {
+      const publicPath = deps.joinPath(vaultPath, 'public', filePath);
+      if (await exists(publicPath)) {
+        return 'public';
+      }
+      return 'content';
+    },
   };
 }
 
@@ -89,3 +102,5 @@ const defaultFileScanner = createFileScanner({
 export const exists = defaultFileScanner.exists;
 export const scanPublicFiles = defaultFileScanner.scanPublicFiles;
 export const scanContentAssetFiles = defaultFileScanner.scanContentAssetFiles;
+export const getAssetSubDir = defaultFileScanner.getAssetSubDir;
+

--- a/scripts/lib/indices.test.ts
+++ b/scripts/lib/indices.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { createIndexGenerator } from './indices';
+import { type FileEntry } from './files';
+
+function file(name: string): FileEntry {
+  return { name, isDirectory: () => false, isFile: () => true };
+}
+
+function directory(name: string): FileEntry {
+  return { name, isDirectory: () => true, isFile: () => false };
+}
+
+describe('createIndexGenerator', () => {
+  it('generates directory indices, root index assets, and thumbnails through injected deps', async () => {
+    const tree: Record<string, FileEntry[]> = {
+      'vault/content': [file('page.md'), directory('blog'), file('hero.png')],
+      'vault/content/blog': [file('post.md')],
+    };
+    const fileContent: Record<string, string> = {
+      'vault/content/page.md': 'home',
+      'vault/content/blog/post.md': 'post',
+    };
+    const writes: Record<string, string> = {};
+    const generateImageThumbnails = vi.fn(async () => undefined);
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const generator = createIndexGenerator({
+      exists: vi.fn(async (filePath: string) => filePath === 'vault/content' || filePath === 'vault/public'),
+      mkdir: vi.fn(async () => undefined),
+      readdir: vi.fn(async (filePath: string) => tree[filePath] || []),
+      readFile: vi.fn(async (filePath: string) => fileContent[filePath] || ''),
+      stat: vi.fn(async () => ({ mtime: new Date('2024-01-03T00:00:00.000Z') })),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      relativePath: path.posix.relative,
+      parseMatter: (content) =>
+        content === 'home'
+          ? { data: { title: 'Home', date: '2024-01-02' }, content: '# Home\nIntro text' }
+          : { data: {}, content: '# Post\nPost excerpt' },
+      normalizeThumbnailSizes: (sizes) => [...(sizes || [])],
+      scanPublicFiles: vi.fn(async () => ['sitemap.xml']),
+      scanContentAssetFiles: vi.fn(async () => ['hero.png']),
+      generateImageThumbnails,
+      logger,
+    });
+
+    const result = await generator.generateIndices({
+      vaultPath: 'vault',
+      thumbnailSizes: [320, 640],
+      dryRun: false,
+    });
+
+    expect(result.rootContentIndex.pages[0].title).toBe('Home');
+    expect(result.allIndices.get('blog')?.pages[0].slug).toBe('post');
+    expect(JSON.parse(writes['vault/root.json'])).toMatchObject({
+      directories: ['blog'],
+      publicFiles: ['hero.png', 'sitemap.xml'],
+      thumbnailSizes: [320, 640],
+    });
+    expect(generateImageThumbnails).toHaveBeenCalledWith({
+      sourceDir: 'vault/content',
+      dryRun: false,
+      thumbnailSizes: [320, 640],
+      label: 'content',
+    });
+  });
+
+  it('throws instead of exiting when content directory is missing', async () => {
+    const generator = createIndexGenerator({
+      exists: vi.fn(async () => false),
+      mkdir: vi.fn(async () => undefined),
+      readdir: vi.fn(async () => []),
+      readFile: vi.fn(async () => ''),
+      stat: vi.fn(async () => ({ mtime: new Date() })),
+      writeFile: vi.fn(async () => undefined),
+      joinPath: path.posix.join,
+      relativePath: path.posix.relative,
+      parseMatter: () => ({ data: {}, content: '' }),
+      normalizeThumbnailSizes: (sizes) => [...(sizes || [])],
+      scanPublicFiles: vi.fn(async () => []),
+      scanContentAssetFiles: vi.fn(async () => []),
+      generateImageThumbnails: vi.fn(async () => undefined),
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await expect(generator.generateIndices({ vaultPath: 'vault', thumbnailSizes: [], dryRun: false })).rejects.toThrow(
+      'content'
+    );
+  });
+});

--- a/scripts/lib/indices.test.ts
+++ b/scripts/lib/indices.test.ts
@@ -90,4 +90,44 @@ describe('createIndexGenerator', () => {
       'content'
     );
   });
+
+  it('strips code blocks when generating excerpt', async () => {
+    const tree: Record<string, FileEntry[]> = {
+      'vault/content': [file('page-with-code.md')],
+    };
+    const fileContent: Record<string, string> = {
+      'vault/content/page-with-code.md': 'content',
+    };
+    const writes: Record<string, string> = {};
+
+    const generator = createIndexGenerator({
+      exists: vi.fn(async (filePath: string) => filePath === 'vault/content'),
+      mkdir: vi.fn(async () => undefined),
+      readdir: vi.fn(async (filePath: string) => tree[filePath] || []),
+      readFile: vi.fn(async (filePath: string) => fileContent[filePath] || ''),
+      stat: vi.fn(async () => ({ mtime: new Date('2024-01-03T00:00:00.000Z') })),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      relativePath: path.posix.relative,
+      parseMatter: () => ({
+        data: { title: 'Code Page', date: '2024-01-02' },
+        content: '# Code Page\n```typescript\nconst a = 1;\n```\nThis is the real first paragraph.',
+      }),
+      normalizeThumbnailSizes: (sizes) => [...(sizes || [])],
+      scanPublicFiles: vi.fn(async () => []),
+      scanContentAssetFiles: vi.fn(async () => []),
+      generateImageThumbnails: vi.fn(async () => undefined),
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    const result = await generator.generateIndices({
+      vaultPath: 'vault',
+      thumbnailSizes: [],
+      dryRun: false,
+    });
+
+    expect(result.rootContentIndex.pages[0].excerpt).toBe('This is the real first paragraph.');
+  });
 });

--- a/scripts/lib/indices.ts
+++ b/scripts/lib/indices.ts
@@ -1,0 +1,262 @@
+import matter from 'gray-matter';
+import { z } from 'zod';
+import { mkdir, readdir, readFile, stat, writeFile } from 'fs/promises';
+import { type Stats } from 'fs';
+import path from 'path';
+import { INDEX_JSON, ROOT_JSON } from '../../src/lib/constants';
+import { PageMetadata, VaultDirectoryIndex, VaultRootIndex } from '../../src/lib/vault';
+import { normalizeThumbnailSizes } from '../../src/lib/responsive-images';
+import { exists, scanContentAssetFiles, scanPublicFiles, type FileEntry } from './files';
+import { generateImageThumbnails } from './thumbnails';
+
+type Logger = Pick<typeof console, 'log' | 'warn' | 'error'>;
+type MatterResult = {
+  data: Record<string, unknown>;
+  content: string;
+};
+
+export type IndexGeneratorDeps = {
+  exists: (path: string) => Promise<boolean>;
+  mkdir: (path: string, options: { recursive: true }) => Promise<string | undefined>;
+  readdir: (path: string, options: { withFileTypes: true }) => Promise<FileEntry[]>;
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
+  stat: (path: string) => Promise<Pick<Stats, 'mtime'>>;
+  writeFile: (path: string, content: string) => Promise<void>;
+  joinPath: (...paths: string[]) => string;
+  relativePath: (from: string, to: string) => string;
+  parseMatter: (content: string) => MatterResult;
+  normalizeThumbnailSizes: (sizes: readonly number[] | undefined) => number[];
+  scanPublicFiles: ({ dir }: { dir: string }) => Promise<string[]>;
+  scanContentAssetFiles: ({ dir }: { dir: string }) => Promise<string[]>;
+  generateImageThumbnails: (input: {
+    sourceDir: string;
+    dryRun: boolean;
+    thumbnailSizes: readonly number[];
+    label: string;
+  }) => Promise<void>;
+  logger: Logger;
+};
+
+const DateInputSchema = z.union([z.string(), z.number(), z.date()]);
+
+function parseSafeDate({
+  dateInput,
+  fallback,
+  label,
+  filePath,
+  logger,
+}: {
+  dateInput: unknown;
+  fallback: Date;
+  label: string;
+  filePath: string;
+  logger: Logger;
+}): string {
+  if (!dateInput) return fallback.toISOString();
+
+  const result = DateInputSchema.safeParse(dateInput);
+  if (!result.success) {
+    logger.warn(
+      `⚠️  Warning: Invalid ${label} type for "${dateInput}" in ${filePath}. Falling back to file modification time.`
+    );
+    return fallback.toISOString();
+  }
+
+  const date = new Date(result.data);
+  if (isNaN(date.getTime())) {
+    logger.warn(
+      `⚠️  Warning: Invalid ${label} value "${dateInput}" in ${filePath}. Falling back to file modification time.`
+    );
+    return fallback.toISOString();
+  }
+
+  return date.toISOString();
+}
+
+export function createIndexGenerator(deps: IndexGeneratorDeps) {
+  async function scanAndGenerate({
+    dir,
+    baseDir,
+    dryRun,
+    allIndices,
+  }: {
+    dir: string;
+    baseDir: string;
+    dryRun: boolean;
+    allIndices: Map<string, VaultDirectoryIndex>;
+  }): Promise<{ index: VaultDirectoryIndex; allDirs: string[] }> {
+    const entries = await deps.readdir(dir, { withFileTypes: true });
+    const pages: PageMetadata[] = [];
+    let allDirs: string[] = [];
+
+    const relDir = deps.relativePath(baseDir, dir).replace(/\\/g, '/');
+
+    for (const entry of entries) {
+      const fullPath = deps.joinPath(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name !== '.git' && entry.name !== 'node_modules') {
+          const result = await scanAndGenerate({ dir: fullPath, baseDir, dryRun, allIndices });
+          const childRelDir = deps.relativePath(baseDir, fullPath).replace(/\\/g, '/');
+          allDirs.push(childRelDir, ...result.allDirs);
+        }
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        const fileContent = await deps.readFile(fullPath, 'utf-8');
+        const fileStats = await deps.stat(fullPath);
+
+        const { data, content } = deps.parseMatter(fileContent);
+
+        if (data.published === false) {
+          continue;
+        }
+
+        const titleMatch = content.match(/^#\s+(.+)$/m);
+        const title =
+          typeof data.title === 'string' && data.title.trim() !== ''
+            ? data.title
+            : titleMatch
+            ? titleMatch[1].trim()
+            : entry.name;
+
+        const relPath = deps.relativePath(baseDir, fullPath).replace(/\\/g, '/');
+        const slug = deps.relativePath(dir, fullPath).replace(/\.md$/, '').replace(/\\/g, '/');
+
+        const date = parseSafeDate({
+          dateInput: data.date,
+          fallback: fileStats.mtime,
+          label: 'date',
+          filePath: relPath,
+          logger: deps.logger,
+        });
+        const manualUpdate = data.updated || data.lastmod;
+        const updatedAt = parseSafeDate({
+          dateInput: manualUpdate,
+          fallback: fileStats.mtime,
+          label: 'updated',
+          filePath: relPath,
+          logger: deps.logger,
+        });
+
+        const firstParagraph = content
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line && !line.startsWith('#') && !line.startsWith('>'))[0];
+
+        let excerpt = '';
+        if (firstParagraph) {
+          excerpt = firstParagraph.slice(0, 160);
+          if (firstParagraph.length > 160) {
+            excerpt += '...';
+          }
+        }
+
+        pages.push({ title, slug, date, updatedAt, excerpt });
+      }
+    }
+
+    pages.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+    const indexData: VaultDirectoryIndex = {
+      version: 1,
+      pages,
+    };
+
+    const indexPath = deps.joinPath(dir, INDEX_JSON);
+    const relDirName = relDir || 'root';
+
+    if (!dryRun) {
+      await deps.writeFile(indexPath, JSON.stringify(indexData, null, 2));
+      deps.logger.log(`✨ Generated index for "${relDirName}"`);
+    }
+
+    allIndices.set(relDir, indexData);
+
+    return { index: indexData, allDirs };
+  }
+
+  return {
+    scanAndGenerate,
+    async generateIndices({
+      vaultPath,
+      thumbnailSizes,
+      dryRun = false,
+    }: {
+      vaultPath: string;
+      thumbnailSizes: readonly number[];
+      dryRun?: boolean;
+    }): Promise<{ rootContentIndex: VaultDirectoryIndex; allIndices: Map<string, VaultDirectoryIndex> }> {
+      const contentDir = deps.joinPath(vaultPath, 'content');
+      if (!(await deps.exists(contentDir))) {
+        throw new Error(`The required "content" directory is missing in the vault: ${vaultPath}`);
+      }
+
+      deps.logger.log(`\n🔍 Recursively scanning "content" directory in ${contentDir}...`);
+      const allIndices = new Map<string, VaultDirectoryIndex>();
+      const { index: rootContentIndex, allDirs } = await scanAndGenerate({
+        dir: contentDir,
+        baseDir: contentDir,
+        dryRun,
+        allIndices,
+      });
+
+      const publicBaseDir = deps.joinPath(vaultPath, 'public');
+      if (!dryRun) {
+        await deps.mkdir(publicBaseDir, { recursive: true });
+      }
+
+      await deps.generateImageThumbnails({
+        sourceDir: contentDir,
+        dryRun,
+        thumbnailSizes,
+        label: 'content',
+      });
+      await deps.generateImageThumbnails({
+        sourceDir: publicBaseDir,
+        dryRun,
+        thumbnailSizes,
+        label: 'public',
+      });
+
+      const publicFiles = (await deps.exists(publicBaseDir)) ? await deps.scanPublicFiles({ dir: publicBaseDir }) : [];
+      const contentAssetFiles = await deps.scanContentAssetFiles({ dir: contentDir });
+      const assetFiles = [...new Set([...publicFiles, ...contentAssetFiles])].sort();
+
+      const rootPath = deps.joinPath(vaultPath, ROOT_JSON);
+      const vaultRootIndex: VaultRootIndex = {
+        ...rootContentIndex,
+        directories: allDirs,
+        publicFiles: assetFiles,
+        thumbnailSizes: deps.normalizeThumbnailSizes(thumbnailSizes),
+      };
+
+      if (dryRun) {
+        deps.logger.log(`[DRY RUN] Would generate master root index at: ${rootPath}`);
+      } else {
+        await deps.writeFile(rootPath, JSON.stringify(vaultRootIndex, null, 2));
+        deps.logger.log(`✨ Generated master root index with ${allDirs.length} directories at: ${rootPath}`);
+      }
+
+      return { rootContentIndex, allIndices };
+    },
+  };
+}
+
+const defaultIndexGenerator = createIndexGenerator({
+  exists,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+  joinPath: path.join,
+  relativePath: path.relative,
+  parseMatter: matter,
+  normalizeThumbnailSizes,
+  scanPublicFiles,
+  scanContentAssetFiles,
+  generateImageThumbnails,
+  logger: console,
+});
+
+export const scanAndGenerate = defaultIndexGenerator.scanAndGenerate;
+export const generateIndices = defaultIndexGenerator.generateIndices;

--- a/scripts/lib/indices.ts
+++ b/scripts/lib/indices.ts
@@ -137,7 +137,8 @@ export function createIndexGenerator(deps: IndexGeneratorDeps) {
           logger: deps.logger,
         });
 
-        const firstParagraph = content
+        const contentWithoutCodeBlocks = content.replace(/```[\s\S]*?```/g, '');
+        const firstParagraph = contentWithoutCodeBlocks
           .split('\n')
           .map((line) => line.trim())
           .filter((line) => line && !line.startsWith('#') && !line.startsWith('>'))[0];

--- a/scripts/lib/sitemaps.test.ts
+++ b/scripts/lib/sitemaps.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { createSitemapGenerator } from './sitemaps';
+
+describe('createSitemapGenerator', () => {
+  it('maps index pages to directory URLs', () => {
+    const generator = createSitemapGenerator({
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async () => undefined),
+      joinPath: path.posix.join,
+      indexSlug: 'page',
+      sitemapXml: 'sitemap.xml',
+      sitemapPagesXml: 'sitemap_pages.xml',
+      logger: { log: vi.fn() },
+    });
+
+    expect(
+      generator.mapPagesToSitemapUrls({
+        domain: 'example.com',
+        relDir: 'blog',
+        pages: [{ title: 'Blog', slug: 'page', date: '2024-01-01', excerpt: '' }],
+      })
+    ).toEqual([{ loc: 'https://example.com/blog', lastmod: '2024-01-01' }]);
+  });
+
+  it('writes a sitemap index when nested sitemaps exist', async () => {
+    const writes: Record<string, string> = {};
+    const generator = createSitemapGenerator({
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      indexSlug: 'page',
+      sitemapXml: 'sitemap.xml',
+      sitemapPagesXml: 'sitemap_pages.xml',
+      logger: { log: vi.fn() },
+    });
+
+    const allIndices = new Map([
+      ['', { version: 1, pages: [] }],
+      ['blog', { version: 1, pages: [{ title: 'Post', slug: 'post', date: '2024-01-02', excerpt: '' }] }],
+    ]);
+
+    await generator.generateSitemaps({
+      vaultPath: 'vault',
+      domain: 'example.com',
+      rootContentIndex: { version: 1, pages: [{ title: 'Home', slug: 'page', date: '2024-01-01', excerpt: '' }] },
+      allIndices,
+      dryRun: false,
+    });
+
+    expect(writes['vault/public/blog/sitemap.xml']).toContain('https://example.com/blog/post');
+    expect(writes['vault/public/sitemap_pages.xml']).toContain('https://example.com/');
+    expect(writes['vault/public/sitemap.xml']).toContain('https://example.com/blog/sitemap.xml');
+  });
+});

--- a/scripts/lib/sitemaps.ts
+++ b/scripts/lib/sitemaps.ts
@@ -1,0 +1,223 @@
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+import { INDEX_SLUG, SITEMAP_PAGES_XML, SITEMAP_XML } from '../../src/lib/constants';
+import { PageMetadata, VaultDirectoryIndex } from '../../src/lib/vault';
+
+type Logger = Pick<typeof console, 'log'>;
+
+export type SitemapGeneratorDeps = {
+  mkdir: (path: string, options: { recursive: true }) => Promise<string | undefined>;
+  writeFile: (path: string, content: string) => Promise<void>;
+  joinPath: (...paths: string[]) => string;
+  indexSlug: string;
+  sitemapXml: string;
+  sitemapPagesXml: string;
+  logger: Logger;
+};
+
+function escapeXml(unsafe: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&apos;',
+  };
+  return unsafe.replace(/[&<>"']/g, (m) => map[m]);
+}
+
+function generateSitemapXml(urls: { loc: string; lastmod?: string }[]): string {
+  const urlTags = urls
+    .map(
+      (url) => `  <url>
+    <loc>${escapeXml(url.loc)}</loc>${url.lastmod ? `\n    <lastmod>${url.lastmod}</lastmod>` : ''}
+  </url>`
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urlTags}
+</urlset>`;
+}
+
+function generateSitemapIndexXml(sitemaps: { loc: string; lastmod?: string }[]): string {
+  const sitemapTags = sitemaps
+    .map(
+      (sitemap) => `  <sitemap>
+    <loc>${escapeXml(sitemap.loc)}</loc>${sitemap.lastmod ? `\n    <lastmod>${sitemap.lastmod}</lastmod>` : ''}
+  </sitemap>`
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${sitemapTags}
+</sitemapindex>`;
+}
+
+export function createSitemapGenerator(deps: SitemapGeneratorDeps) {
+  function mapPagesToSitemapUrls({
+    pages,
+    domain,
+    relDir = '',
+  }: {
+    pages: PageMetadata[];
+    domain: string;
+    relDir?: string;
+  }) {
+    return pages.map((page) => {
+      const urlPath = page.slug === deps.indexSlug ? relDir : relDir ? `${relDir}/${page.slug}` : page.slug;
+      return {
+        loc: `https://${domain}/${urlPath}`,
+        lastmod: page.updatedAt || page.date,
+      };
+    });
+  }
+
+  async function writeSitemapFile({
+    fullPath,
+    relPath,
+    content,
+    dryRun,
+    label,
+  }: {
+    fullPath: string;
+    relPath: string;
+    content: string;
+    dryRun: boolean;
+    label: string;
+  }) {
+    if (!dryRun) {
+      const dir = deps.joinPath(fullPath, '..');
+      await deps.mkdir(dir, { recursive: true });
+      await deps.writeFile(fullPath, content);
+      deps.logger.log(`✨ Generated ${label} at ${relPath}`);
+    } else {
+      deps.logger.log(`[DRY RUN] Would generate ${label} at ${relPath}`);
+    }
+  }
+
+  async function generateAllSitemaps({
+    domain,
+    allIndices,
+    vaultPath,
+    dryRun,
+  }: {
+    domain: string;
+    allIndices: Map<string, VaultDirectoryIndex>;
+    vaultPath: string;
+    dryRun: boolean;
+  }): Promise<string[]> {
+    const subSitemaps: string[] = [];
+    for (const [relDir, indexData] of allIndices.entries()) {
+      if (relDir === '') continue;
+      if (indexData.pages.length === 0) continue;
+
+      const sitemapUrls = mapPagesToSitemapUrls({ pages: indexData.pages, domain, relDir });
+      const sitemapContent = generateSitemapXml(sitemapUrls);
+      const sitemapPath = deps.joinPath(vaultPath, 'public', relDir, deps.sitemapXml);
+      const relSitemapPath = `public/${relDir}/${deps.sitemapXml}`;
+
+      await writeSitemapFile({
+        fullPath: sitemapPath,
+        relPath: relSitemapPath,
+        content: sitemapContent,
+        dryRun,
+        label: `sitemap for "${relDir}"`,
+      });
+      subSitemaps.push(`${relDir}/${deps.sitemapXml}`);
+    }
+    return subSitemaps;
+  }
+
+  return {
+    mapPagesToSitemapUrls,
+    writeSitemapFile,
+    generateAllSitemaps,
+    async generateSitemaps({
+      vaultPath,
+      domain,
+      rootContentIndex,
+      allIndices,
+      dryRun,
+    }: {
+      vaultPath: string;
+      domain: string | undefined;
+      rootContentIndex: VaultDirectoryIndex;
+      allIndices: Map<string, VaultDirectoryIndex>;
+      dryRun: boolean;
+    }) {
+      if (!domain) {
+        deps.logger.log('ℹ️  Skipping sitemap generation because "domain" is not configured in registry.json');
+        return;
+      }
+
+      const publicBaseDir = deps.joinPath(vaultPath, 'public');
+      const subSitemaps = await generateAllSitemaps({ domain, allIndices, vaultPath, dryRun });
+      const rootPages = rootContentIndex.pages;
+      const sitemapUrls = rootPages.length > 0 ? mapPagesToSitemapUrls({ pages: rootPages, domain }) : [];
+
+      if (subSitemaps.length === 0) {
+        if (sitemapUrls.length > 0) {
+          const sitemapContent = generateSitemapXml(sitemapUrls);
+          const sitemapPath = deps.joinPath(publicBaseDir, deps.sitemapXml);
+          await writeSitemapFile({
+            fullPath: sitemapPath,
+            relPath: `public/${deps.sitemapXml}`,
+            content: sitemapContent,
+            dryRun,
+            label: 'sitemap',
+          });
+        }
+        return;
+      }
+
+      const sitemaps = [];
+
+      if (sitemapUrls.length > 0) {
+        const sitemapContent = generateSitemapXml(sitemapUrls);
+        const sitemapPath = deps.joinPath(publicBaseDir, deps.sitemapPagesXml);
+        await writeSitemapFile({
+          fullPath: sitemapPath,
+          relPath: `public/${deps.sitemapPagesXml}`,
+          content: sitemapContent,
+          dryRun,
+          label: 'root pages sitemap',
+        });
+        sitemaps.push({ loc: `https://${domain}/${deps.sitemapPagesXml}` });
+      }
+
+      for (const subSitemap of subSitemaps) {
+        sitemaps.push({ loc: `https://${domain}/${subSitemap}` });
+      }
+
+      if (sitemaps.length > 0) {
+        const sitemapIndexContent = generateSitemapIndexXml(sitemaps);
+        const sitemapIndexPath = deps.joinPath(publicBaseDir, deps.sitemapXml);
+        await writeSitemapFile({
+          fullPath: sitemapIndexPath,
+          relPath: `public/${deps.sitemapXml}`,
+          content: sitemapIndexContent,
+          dryRun,
+          label: 'master sitemap index',
+        });
+      }
+    },
+  };
+}
+
+const defaultSitemapGenerator = createSitemapGenerator({
+  mkdir,
+  writeFile,
+  joinPath: path.join,
+  indexSlug: INDEX_SLUG,
+  sitemapXml: SITEMAP_XML,
+  sitemapPagesXml: SITEMAP_PAGES_XML,
+  logger: console,
+});
+
+export const mapPagesToSitemapUrls = defaultSitemapGenerator.mapPagesToSitemapUrls;
+export const writeSitemapFile = defaultSitemapGenerator.writeSitemapFile;
+export const generateAllSitemaps = defaultSitemapGenerator.generateAllSitemaps;
+export const generateSitemaps = defaultSitemapGenerator.generateSitemaps;

--- a/scripts/lib/thumbnails.test.ts
+++ b/scripts/lib/thumbnails.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { createThumbnailGenerator } from './thumbnails';
+import { type FileEntry } from './files';
+
+function file(name: string): FileEntry {
+  return { name, isDirectory: () => false, isFile: () => true };
+}
+
+function directory(name: string): FileEntry {
+  return { name, isDirectory: () => true, isFile: () => false };
+}
+
+describe('createThumbnailGenerator', () => {
+  function makeGenerator() {
+    const tree: Record<string, FileEntry[]> = {
+      root: [file('hero.png'), file('notes.txt'), directory('_thumbnails'), directory('gallery')],
+      'root/_thumbnails': [file('hero-320.webp')],
+      'root/gallery': [file('nested.jpg')],
+    };
+    const mkdir = vi.fn(async () => undefined);
+    const processImage = vi.fn(async () => undefined);
+    const logger = { log: vi.fn() };
+
+    const generator = createThumbnailGenerator({
+      exists: vi.fn(async (filePath: string) => Boolean(tree[filePath])),
+      readdir: vi.fn(async (filePath: string) => tree[filePath] || []),
+      mkdir,
+      joinPath: path.posix.join,
+      relativePath: path.posix.relative,
+      dirnamePath: path.posix.dirname,
+      generatedThumbnailDir: '_thumbnails',
+      normalizeThumbnailSizes: (sizes) => [...(sizes || [])].sort((a, b) => a - b),
+      isSupportedResponsiveImage: (filePath) => ['.jpg', '.png'].includes(path.posix.extname(filePath)),
+      isGeneratedThumbnailPath: (filePath) => filePath.split('/').includes('_thumbnails'),
+      getThumbnailPath: ({ imagePath, width }) => `_thumbnails/${imagePath.replace(/\.[^.]+$/, `-${width}.webp`)}`,
+      processImage,
+      logger,
+    });
+
+    return { generator, mkdir, processImage, logger };
+  }
+
+  it('collects supported source images and skips generated thumbnails', async () => {
+    const { generator } = makeGenerator();
+
+    await expect(generator.collectSourceImages({ dir: 'root' })).resolves.toEqual(['hero.png', 'gallery/nested.jpg']);
+  });
+
+  it('injects image processing and directory creation for generated thumbnails', async () => {
+    const { generator, mkdir, processImage } = makeGenerator();
+
+    await generator.generateImageThumbnails({
+      sourceDir: 'root',
+      dryRun: false,
+      thumbnailSizes: [640, 320],
+      label: 'content',
+    });
+
+    expect(mkdir).toHaveBeenCalledWith('root/_thumbnails', { recursive: true });
+    expect(processImage).toHaveBeenCalledWith({
+      inputPath: 'root/hero.png',
+      outputPath: 'root/_thumbnails/hero-320.webp',
+      width: 320,
+    });
+    expect(processImage).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not process images during dry runs', async () => {
+    const { generator, mkdir, processImage, logger } = makeGenerator();
+
+    await generator.generateImageThumbnails({
+      sourceDir: 'root',
+      dryRun: true,
+      thumbnailSizes: [320],
+      label: 'content',
+    });
+
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(processImage).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith('[DRY RUN] Would generate content thumbnail: _thumbnails/hero-320.webp');
+  });
+});

--- a/scripts/lib/thumbnails.ts
+++ b/scripts/lib/thumbnails.ts
@@ -1,0 +1,131 @@
+import sharp from 'sharp';
+import { mkdir, readdir } from 'fs/promises';
+import path from 'path';
+import { THUMBNAILS_DIR } from '../../src/lib/constants';
+import {
+  getThumbnailPath,
+  isGeneratedThumbnailPath,
+  isSupportedResponsiveImage,
+  normalizeThumbnailSizes,
+} from '../../src/lib/responsive-images';
+import { exists } from './files';
+import { type FileEntry } from './files';
+
+type Logger = Pick<typeof console, 'log'>;
+
+export type ThumbnailGeneratorDeps = {
+  exists: (path: string) => Promise<boolean>;
+  readdir: (path: string, options: { withFileTypes: true }) => Promise<FileEntry[]>;
+  mkdir: (path: string, options: { recursive: true }) => Promise<string | undefined>;
+  joinPath: (...paths: string[]) => string;
+  relativePath: (from: string, to: string) => string;
+  dirnamePath: (path: string) => string;
+  generatedThumbnailDir: string;
+  normalizeThumbnailSizes: (sizes: readonly number[] | undefined) => number[];
+  isSupportedResponsiveImage: (filePath: string) => boolean;
+  isGeneratedThumbnailPath: (filePath: string) => boolean;
+  getThumbnailPath: ({ imagePath, width }: { imagePath: string; width: number }) => string;
+  processImage: ({ inputPath, outputPath, width }: { inputPath: string; outputPath: string; width: number }) => Promise<void>;
+  logger: Logger;
+};
+
+export function createThumbnailGenerator(deps: ThumbnailGeneratorDeps) {
+  async function collectSourceImages({ dir, baseDir = dir }: { dir: string; baseDir?: string }): Promise<string[]> {
+    const files: string[] = [];
+
+    async function walk(currentDir: string) {
+      if (!(await deps.exists(currentDir))) return;
+      const entries = await deps.readdir(currentDir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = deps.joinPath(currentDir, entry.name);
+
+        if (entry.isDirectory()) {
+          if (entry.name !== '.git' && entry.name !== 'node_modules' && entry.name !== deps.generatedThumbnailDir) {
+            await walk(fullPath);
+          }
+        } else if (entry.isFile()) {
+          const relPath = deps.relativePath(baseDir, fullPath).replace(/\\/g, '/');
+          if (deps.isSupportedResponsiveImage(relPath) && !deps.isGeneratedThumbnailPath(relPath)) {
+            files.push(relPath);
+          }
+        }
+      }
+    }
+
+    await walk(dir);
+    return files;
+  }
+
+  return {
+    collectSourceImages,
+    async generateImageThumbnails({
+      sourceDir,
+      dryRun,
+      thumbnailSizes,
+      label,
+    }: {
+      sourceDir: string;
+      dryRun: boolean;
+      thumbnailSizes: readonly number[];
+      label: string;
+    }): Promise<void> {
+      if (!(await deps.exists(sourceDir))) return;
+
+      const sizes = deps.normalizeThumbnailSizes(thumbnailSizes);
+      const imageFiles = await collectSourceImages({ dir: sourceDir });
+
+      if (imageFiles.length === 0) {
+        deps.logger.log(`ℹ️  No responsive image thumbnails needed for ${label}.`);
+        return;
+      }
+
+      let generatedCount = 0;
+      for (const imageFile of imageFiles) {
+        const inputPath = deps.joinPath(sourceDir, imageFile);
+
+        for (const width of sizes) {
+          const thumbnailRelPath = deps.getThumbnailPath({ imagePath: imageFile, width });
+          const outputPath = deps.joinPath(sourceDir, thumbnailRelPath);
+
+          if (dryRun) {
+            deps.logger.log(`[DRY RUN] Would generate ${label} thumbnail: ${thumbnailRelPath}`);
+            generatedCount += 1;
+            continue;
+          }
+
+          await deps.mkdir(deps.dirnamePath(outputPath), { recursive: true });
+          await deps.processImage({ inputPath, outputPath, width });
+          generatedCount += 1;
+        }
+      }
+
+      deps.logger.log(`✨ Generated ${generatedCount} ${label} responsive image thumbnails.`);
+    },
+  };
+}
+
+const defaultThumbnailGenerator = createThumbnailGenerator({
+  exists,
+  readdir,
+  mkdir,
+  joinPath: path.join,
+  relativePath: path.relative,
+  dirnamePath: path.dirname,
+  generatedThumbnailDir: THUMBNAILS_DIR,
+  normalizeThumbnailSizes,
+  isSupportedResponsiveImage,
+  isGeneratedThumbnailPath,
+  getThumbnailPath,
+  processImage: async ({ inputPath, outputPath, width }) => {
+    await sharp(inputPath)
+      .rotate()
+      .resize({ width, withoutEnlargement: true })
+      .webp({ quality: 82 })
+      .toFile(outputPath);
+  },
+  logger: console,
+});
+
+export const collectSourceImages = defaultThumbnailGenerator.collectSourceImages;
+export const generateImageThumbnails = defaultThumbnailGenerator.generateImageThumbnails;

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -5,7 +5,7 @@ import { VaultDirectoryIndex } from '../../src/lib/vault';
 
 // Mock dependency modules
 vi.mock('./files', () => ({
-  exists: vi.fn(),
+  getAssetSubDir: vi.fn(),
 }));
 
 vi.mock('fs/promises', () => ({
@@ -14,7 +14,7 @@ vi.mock('fs/promises', () => ({
 }));
 
 // Access mocked functions
-import { exists } from './files';
+import { getAssetSubDir } from './files';
 import { readFile, readdir } from 'fs/promises';
 
 describe('WordPress Deployment Library', () => {
@@ -39,7 +39,7 @@ describe('WordPress Deployment Library', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default mock implementation
-    vi.mocked(exists).mockResolvedValue(true);
+    vi.mocked(getAssetSubDir).mockResolvedValue('content');
     vi.mocked(readFile).mockResolvedValue('# My Post Title\nThis is content.');
     global.fetch = vi.fn();
   });
@@ -50,9 +50,7 @@ describe('WordPress Deployment Library', () => {
       const sizes = [300, 600, 1200];
 
       // Simulate that the file exists in the "content" directory
-      vi.mocked(exists).mockImplementation(async (filePath) => {
-        return filePath.toString().includes('content/_thumbnails');
-      });
+      vi.mocked(getAssetSubDir).mockResolvedValue('content');
 
       const result = await replaceLocalImagesWithThumbnails({
         html,
@@ -62,7 +60,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<img src="https://cdn.testsite.com/content/_thumbnails/images/pic-1200.webp" alt="Pic" />'
+        '<img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" alt="Pic" />'
       );
     });
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -60,7 +60,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Pic" loading="lazy" decoding="async" />'
+        '<img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Pic" style="max-width:100%;" loading="lazy" decoding="async" />'
       );
     });
 
@@ -78,7 +78,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" srcset="https://testsite.com/api/vault-public/_thumbnails/pic-300.webp 300w, https://testsite.com/api/vault-public/_thumbnails/pic-600.webp 600w, https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Direct" loading="lazy" decoding="async" />'
+        '<img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" srcset="https://testsite.com/api/vault-public/_thumbnails/pic-300.webp 300w, https://testsite.com/api/vault-public/_thumbnails/pic-600.webp 600w, https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Direct" style="max-width:100%;" loading="lazy" decoding="async" />'
       );
     });
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -10,11 +10,12 @@ vi.mock('./files', () => ({
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
+  readdir: vi.fn(),
 }));
 
 // Access mocked functions
 import { exists } from './files';
-import { readFile } from 'fs/promises';
+import { readFile, readdir } from 'fs/promises';
 
 describe('WordPress Deployment Library', () => {
   const mockSite: Site = {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -60,7 +60,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Pic" style="max-width:100%;" loading="lazy" decoding="async" />'
+        '<img decoding="async" loading="lazy" style="max-width:100%;" sizes="(max-width: 1200px) 100vw, 1200px" srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp 1200w" src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" alt="Pic" />'
       );
     });
 
@@ -78,8 +78,27 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" srcset="https://testsite.com/api/vault-public/_thumbnails/pic-300.webp 300w, https://testsite.com/api/vault-public/_thumbnails/pic-600.webp 600w, https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Direct" style="max-width:100%;" loading="lazy" decoding="async" />'
+        '<img decoding="async" loading="lazy" style="max-width:100%;" sizes="(max-width: 1200px) 100vw, 1200px" srcset="https://testsite.com/api/vault-public/_thumbnails/pic-300.webp 300w, https://testsite.com/api/vault-public/_thumbnails/pic-600.webp 600w, https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp 1200w" src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" alt="Direct" />'
       );
+    });
+
+    it('should preserve original image attributes like class, width, height', async () => {
+      const html = '<img src="/images/pic.png" class="aligncenter custom-class" width="800" height="600" alt="Pic" />';
+      const sizes = [300, 600, 1200];
+
+      vi.mocked(getAssetSubDir).mockResolvedValue('content');
+
+      const result = await replaceLocalImagesWithThumbnails({
+        html,
+        site: mockSite,
+        registry: mockRegistry,
+        sizes,
+      });
+
+      expect(result).toContain('class="aligncenter custom-class"');
+      expect(result).toContain('width="800"');
+      expect(result).toContain('height="600"');
+      expect(result).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp"');
     });
 
     it('should ignore external URLs and data URIs', async () => {
@@ -204,7 +223,7 @@ describe('WordPress Deployment Library', () => {
 
       // Assert lookup and create calls
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/wp/v2/posts?slug=blog%2Fpost-two'),
+        expect.stringContaining('/wp/v2/posts?slug=blog-post-two'),
         expect.objectContaining({ method: 'GET' })
       );
       expect(mockFetch).toHaveBeenCalledWith(
@@ -241,6 +260,43 @@ describe('WordPress Deployment Library', () => {
       // Verify no POST methods were called
       const postCalls = mockFetch.mock.calls.filter((call) => call[1]?.method === 'POST');
       expect(postCalls.length).toBe(0);
+    });
+
+    it('should strip only the first H1 when it is the first non-empty line and outside code blocks', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 789 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      // Mock markdown content with a code comment at the top, and a real title later
+      vi.mocked(readFile).mockResolvedValue('```bash\n# This is a comment\necho "hello"\n```\n# Real Title\nThis is actual content.');
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetPostSlug: 'post-one',
+        dryRun: false,
+      });
+
+      // Verify that the comment is kept and the title '# Real Title' is kept (not stripped, because there is content before it)
+      const postCall = mockFetch.mock.calls.find((call) => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body);
+      expect(body.content).toContain('# This is a comment');
+      expect(body.content).toContain('<h1>Real Title</h1>');
     });
   });
 });

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -1,0 +1,247 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { replaceLocalImagesWithThumbnails, pushToWordPress } from './wordpress';
+import { Site, Registry } from '../../src/domain/registry';
+import { VaultDirectoryIndex } from '../../src/lib/vault';
+
+// Mock dependency modules
+vi.mock('./files', () => ({
+  exists: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+// Access mocked functions
+import { exists } from './files';
+import { readFile } from 'fs/promises';
+
+describe('WordPress Deployment Library', () => {
+  const mockSite: Site = {
+    siteId: 'test-blog',
+    vaultPath: '/mock/vault',
+    domain: 'testsite.com',
+    imageHost: 'https://cdn.testsite.com',
+    wordpress: {
+      username: 'user123',
+      applicationPassword: 'pwd-abc-xyz',
+      endpoint: 'https://testsite.com/wp-json',
+    },
+    thumbnailSizes: [300, 600, 1200],
+  };
+
+  const mockRegistry: Registry = {
+    sites: [mockSite],
+    thumbnailSizes: [300, 600, 1200],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock implementation
+    vi.mocked(exists).mockResolvedValue(true);
+    vi.mocked(readFile).mockResolvedValue('# My Post Title\nThis is content.');
+    global.fetch = vi.fn();
+  });
+
+  describe('replaceLocalImagesWithThumbnails', () => {
+    it('should replace local image sources with absolute CDN URLs pointing to the largest thumbnail', async () => {
+      const html = '<p>Hello world</p><img src="/images/pic.png" alt="Pic" />';
+      const sizes = [300, 600, 1200];
+
+      // Simulate that the file exists in the "content" directory
+      vi.mocked(exists).mockImplementation(async (filePath) => {
+        return filePath.toString().includes('content/_thumbnails');
+      });
+
+      const result = await replaceLocalImagesWithThumbnails({
+        html,
+        site: mockSite,
+        registry: mockRegistry,
+        sizes,
+      });
+
+      expect(result).toContain(
+        '<img src="https://cdn.testsite.com/content/_thumbnails/images/pic-1200.webp" alt="Pic" />'
+      );
+    });
+
+    it('should fallback to site domain if imageHost is not provided', async () => {
+      const html = '<img src="/pic.png" alt="Direct" />';
+      const sizes = [300, 600, 1200];
+
+      const siteWithoutImageHost = { ...mockSite, imageHost: undefined };
+
+      const result = await replaceLocalImagesWithThumbnails({
+        html,
+        site: siteWithoutImageHost,
+        registry: { ...mockRegistry, imageHost: undefined },
+        sizes,
+      });
+
+      expect(result).toContain(
+        '<img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" alt="Direct" />'
+      );
+    });
+
+    it('should ignore external URLs and data URIs', async () => {
+      const html = `
+        <img src="https://external.com/photo.jpg" alt="Ext" />
+        <img src="data:image/png;base64,abc" alt="Data" />
+        <img src="#hash" alt="Hash" />
+      `;
+      const sizes = [300, 600, 1200];
+
+      const result = await replaceLocalImagesWithThumbnails({
+        html,
+        site: mockSite,
+        registry: mockRegistry,
+        sizes,
+      });
+
+      expect(result).toContain('src="https://external.com/photo.jpg"');
+      expect(result).toContain('src="data:image/png;base64,abc"');
+      expect(result).toContain('src="#hash"');
+    });
+  });
+
+  describe('pushToWordPress', () => {
+    const mockIndices = new Map<string, VaultDirectoryIndex>([
+      [
+        '',
+        {
+          version: 1,
+          pages: [
+            {
+              title: 'Post One',
+              slug: 'post-one',
+              date: '2026-06-16T12:00:00.000Z',
+              excerpt: 'An excerpt.',
+            },
+          ],
+        },
+      ],
+      [
+        'blog',
+        {
+          version: 1,
+          pages: [
+            {
+              title: 'Post Two',
+              slug: 'post-two',
+              date: '2026-06-16T13:00:00.000Z',
+              excerpt: 'Another excerpt.',
+            },
+          ],
+        },
+      ],
+    ]);
+
+    it('should perform GET queries to check for existence and POST queries to update when the post exists', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        // Query GET matches
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [{ id: 456, title: { rendered: 'Post One' } }],
+          };
+        }
+        // Update POST matches
+        if (url.includes('/wp/v2/posts/456') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 456 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetPostSlug: 'post-one',
+        dryRun: false,
+      });
+
+      // Assert fetch calls
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts?slug=post-one'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts/456'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should perform GET queries and POST to create a new post when it does not exist', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        // Query GET matches empty array
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        // Create POST matches
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 789 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetPostSlug: 'blog/post-two',
+        dryRun: false,
+      });
+
+      // Assert lookup and create calls
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts?slug=blog%2Fpost-two'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should only query and perform no mutations when dryRun is true', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetPostSlug: 'post-one',
+        dryRun: true,
+      });
+
+      // Verified GET was called
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts?slug=post-one'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      // Verify no POST methods were called
+      const postCalls = mockFetch.mock.calls.filter((call) => call[1]?.method === 'POST');
+      expect(postCalls.length).toBe(0);
+    });
+  });
+});

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -60,7 +60,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<figure class="wp-block-image"><img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" alt="Pic" /><figcaption>Pic</figcaption></figure>'
+        '<img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Pic" loading="lazy" decoding="async" />'
       );
     });
 
@@ -78,7 +78,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<figure class="wp-block-image"><img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" alt="Direct" /><figcaption>Direct</figcaption></figure>'
+        '<img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" srcset="https://testsite.com/api/vault-public/_thumbnails/pic-300.webp 300w, https://testsite.com/api/vault-public/_thumbnails/pic-600.webp 600w, https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp 1200w" sizes="(max-width: 1200px) 100vw, 1200px" alt="Direct" loading="lazy" decoding="async" />'
       );
     });
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -60,7 +60,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" alt="Pic" />'
+        '<figure class="wp-block-image"><img src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" alt="Pic" /><figcaption>Pic</figcaption></figure>'
       );
     });
 
@@ -78,7 +78,7 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(result).toContain(
-        '<img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" alt="Direct" />'
+        '<figure class="wp-block-image"><img src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" alt="Direct" /><figcaption>Direct</figcaption></figure>'
       );
     });
 

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -35,7 +35,7 @@ async function wpFetch({
 }: WpFetchArgs) {
   const url = `${endpoint.replace(/\/+$/, '')}${apiPath}`;
   const auth = Buffer.from(`${credentials.username}:${credentials.applicationPassword}`).toString('base64');
-  
+
   const headers: Record<string, string> = {
     'Authorization': `Basic ${auth}`,
   };
@@ -119,10 +119,12 @@ export async function replaceLocalImagesWithThumbnails({
       domain: site.domain,
     });
 
-    // Preserve the alt text attribute if present
+    // Preserve the alt text attribute if present and use it as a caption
     const altMatch = fullMatch.match(/alt=["']([^"']*)["']/i);
-    const altAttr = altMatch ? ` alt="${altMatch[1]}"` : '';
-    const newImgTag = `<img src="${encodeURI(absoluteUrl)}"${altAttr} />`;
+    const altText = altMatch ? altMatch[1] : '';
+    const altAttr = altText ? ` alt="${altText}"` : '';
+    const figcaption = altText ? `<figcaption>${altText}</figcaption>` : '';
+    const newImgTag = `<figure class="wp-block-image"><img src="${encodeURI(absoluteUrl)}"${altAttr} />${figcaption}</figure>`;
 
     processedHtml = processedHtml.replaceAll(fullMatch, newImgTag);
   }

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -1,11 +1,11 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 import matter from 'gray-matter';
-import { exists } from './files';
+import { getAssetSubDir } from './files';
 import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
-import { getThumbnailPath, normalizeThumbnailSizes } from '../../src/lib/responsive-images';
+import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl } from '../../src/lib/responsive-images';
 
 interface PushToWordPressArgs {
   site: Site;
@@ -108,23 +108,16 @@ export async function replaceLocalImagesWithThumbnails({
     const thumbPath = getThumbnailPath({ imagePath: decodedSrc, width: largestWidth });
 
     // Determine target location in S3 by checking local filesystem existence
-    const contentThumbPath = path.join(site.vaultPath, 'content', thumbPath);
-    const publicThumbPath = path.join(site.vaultPath, 'public', thumbPath);
-
-    let s3SubDir = 'content';
-    if (await exists(publicThumbPath)) {
-      s3SubDir = 'public';
-    } else if (await exists(contentThumbPath)) {
-      s3SubDir = 'content';
-    }
+    const s3SubDir = await getAssetSubDir({ vaultPath: site.vaultPath, filePath: thumbPath });
 
     // Build the absolute URL on the configured imageHost
-    let absoluteUrl: string;
-    if (imageHost) {
-      absoluteUrl = `${imageHost.replace(/\/+$/, '')}/${s3SubDir}/${thumbPath}`;
-    } else {
-      absoluteUrl = `https://${site.domain || 'localhost'}/api/vault-public/${thumbPath}`;
-    }
+    const absoluteUrl = getAssetUrl({
+      imageHost,
+      siteId: site.siteId,
+      s3SubDir,
+      filePath: thumbPath,
+      domain: site.domain,
+    });
 
     // Preserve the alt text attribute if present
     const altMatch = fullMatch.match(/alt=["']([^"']*)["']/i);

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -5,7 +5,17 @@ import { getAssetSubDir } from './files';
 import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
-import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl } from '../../src/lib/responsive-images';
+import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl, RESPONSIVE_IMAGE_SIZES } from '../../src/lib/responsive-images';
+
+/**
+ * Maps a numeric image width to standard WordPress image size classes.
+ */
+export function getImageSizeClass(width: number): string {
+  if (width <= 150) return 'size-thumbnail';
+  if (width <= 300) return 'size-medium';
+  if (width <= 1024) return 'size-large';
+  return 'size-full';
+}
 
 interface PushToWordPressArgs {
   site: Site;
@@ -119,12 +129,27 @@ export async function replaceLocalImagesWithThumbnails({
       domain: site.domain,
     });
 
-    // Preserve the alt text attribute if present and use it as a caption
+    // Build the srcset attributes for all defined thumbnail sizes
+    const srcSetUrls = sizes.map((size) => {
+      const sizeThumbPath = getThumbnailPath({ imagePath: decodedSrc, width: size });
+      const sizeUrl = getAssetUrl({
+        imageHost,
+        siteId: site.siteId,
+        s3SubDir,
+        filePath: sizeThumbPath,
+        domain: site.domain,
+      });
+      return `${encodeURI(sizeUrl)} ${size}w`;
+    }).join(', ');
+
+    const srcSetAttr = srcSetUrls ? ` srcset="${srcSetUrls}"` : '';
+    const sizesAttr = srcSetUrls ? ` sizes="(max-width: ${largestWidth}px) 100vw, ${largestWidth}px"` : '';
+
+    // Preserve the alt text attribute if present
     const altMatch = fullMatch.match(/alt=["']([^"']*)["']/i);
     const altText = altMatch ? altMatch[1] : '';
     const altAttr = altText ? ` alt="${altText}"` : '';
-    const figcaption = altText ? `<figcaption>${altText}</figcaption>` : '';
-    const newImgTag = `<figure class="wp-block-image"><img src="${encodeURI(absoluteUrl)}"${altAttr} />${figcaption}</figure>`;
+    const newImgTag = `<img src="${encodeURI(absoluteUrl)}"${srcSetAttr}${sizesAttr}${altAttr} loading="lazy" decoding="async" />`;
 
     processedHtml = processedHtml.replaceAll(fullMatch, newImgTag);
   }
@@ -213,6 +238,13 @@ export async function pushToWordPress({
         markdown: bodyWithoutTitle,
         thumbnailSizes: sizes,
         publicFiles,
+        getFigureProperties: (largestWidth) => {
+          const sizeClass = getImageSizeClass(largestWidth);
+          return {
+            class: `wp-block-image ${sizeClass}`,
+            style: 'height: auto !important;',
+          };
+        },
       });
 
       // Replace local image paths with imageHost absolute thumbnail URLs

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -80,14 +80,15 @@ export async function replaceLocalImagesWithThumbnails({
     return html;
   }
 
+  let processedHtml = html;
+
+  // Process HTML <img> tags
   const imgRegex = /<img\s+([^>]*src=["']([^"']+)["'][^>]*?)>/gi;
   const matches: { fullMatch: string; src: string }[] = [];
   let match;
-  while ((match = imgRegex.exec(html)) !== null) {
+  while ((match = imgRegex.exec(processedHtml)) !== null) {
     matches.push({ fullMatch: match[0], src: match[2] });
   }
-
-  let processedHtml = html;
 
   for (const { fullMatch, src } of matches) {
     // Skip external or inline assets
@@ -162,6 +163,16 @@ export async function pushToWordPress({
   }
   console.log(dryRun ? `- Mode: DRY RUN (No changes will be written)\n` : `- Mode: Live Sync\n`);
 
+  // Load public files from root.json if it exists
+  let publicFiles: string[] = [];
+  try {
+    const rootIndexRaw = await readFile(path.join(site.vaultPath, 'root.json'), 'utf-8');
+    const rootIndex = JSON.parse(rootIndexRaw);
+    publicFiles = rootIndex.publicFiles || [];
+  } catch (err) {
+    // If root.json is not found or not yet generated, fallback to empty array
+  }
+
   // Collect all posts from directory indices
   const postsToPublish: { localPath: string; slug: string; title: string; date: string }[] = [];
 
@@ -206,6 +217,7 @@ export async function pushToWordPress({
       let htmlContent = await renderMarkdownContent({
         markdown: bodyWithoutTitle,
         thumbnailSizes: sizes,
+        publicFiles,
       });
 
       // Replace local image paths with imageHost absolute thumbnail URLs

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -7,15 +7,6 @@ import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
 import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl, RESPONSIVE_IMAGE_SIZES } from '../../src/lib/responsive-images';
 
-/**
- * Maps a numeric image width to standard WordPress image size classes.
- */
-export function getImageSizeClass(width: number): string {
-  if (width <= 150) return 'size-thumbnail';
-  if (width <= 300) return 'size-medium';
-  if (width <= 1024) return 'size-large';
-  return 'size-full';
-}
 
 interface PushToWordPressArgs {
   site: Site;
@@ -149,7 +140,7 @@ export async function replaceLocalImagesWithThumbnails({
     const altMatch = fullMatch.match(/alt=["']([^"']*)["']/i);
     const altText = altMatch ? altMatch[1] : '';
     const altAttr = altText ? ` alt="${altText}"` : '';
-    const newImgTag = `<img src="${encodeURI(absoluteUrl)}"${srcSetAttr}${sizesAttr}${altAttr} loading="lazy" decoding="async" />`;
+    const newImgTag = `<img src="${encodeURI(absoluteUrl)}"${srcSetAttr}${sizesAttr}${altAttr} style="max-width:100%;" loading="lazy" decoding="async" />`;
 
     processedHtml = processedHtml.replaceAll(fullMatch, newImgTag);
   }
@@ -239,9 +230,8 @@ export async function pushToWordPress({
         thumbnailSizes: sizes,
         publicFiles,
         getFigureProperties: (largestWidth) => {
-          const sizeClass = getImageSizeClass(largestWidth);
           return {
-            class: `wp-block-image ${sizeClass}`,
+            class: 'wp-block-image',
             style: 'height: auto !important;',
           };
         },

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -21,7 +21,7 @@ interface WpFetchArgs {
   credentials: { username: string; applicationPassword: string };
   path: string;
   method?: string;
-  body?: any;
+  body?: unknown;
 }
 
 /**
@@ -91,7 +91,12 @@ export async function replaceLocalImagesWithThumbnails({
     matches.push({ fullMatch: match[0], src: match[2] });
   }
 
-  for (const { fullMatch, src } of matches) {
+  // Deduplicate matches to avoid redundant checks/replacements
+  const uniqueMatches = Array.from(
+    new Map(matches.map((m) => [m.fullMatch, m])).values()
+  );
+
+  for (const { fullMatch, src } of uniqueMatches) {
     // Skip external or inline assets
     if (
       src.startsWith('http://') ||
@@ -133,19 +138,54 @@ export async function replaceLocalImagesWithThumbnails({
       return `${encodeURI(sizeUrl)} ${size}w`;
     }).join(', ');
 
-    const srcSetAttr = srcSetUrls ? ` srcset="${srcSetUrls}"` : '';
-    const sizesAttr = srcSetUrls ? ` sizes="(max-width: ${largestWidth}px) 100vw, ${largestWidth}px"` : '';
+    let newImgTag = fullMatch;
+    
+    // Replace src in-place
+    newImgTag = newImgTag.replace(/src=["']([^"']*)["']/i, `src="${encodeURI(absoluteUrl)}"`);
 
-    // Preserve the alt text attribute if present
-    const altMatch = fullMatch.match(/alt=["']([^"']*)["']/i);
-    const altText = altMatch ? altMatch[1] : '';
-    const altAttr = altText ? ` alt="${altText}"` : '';
-    const newImgTag = `<img src="${encodeURI(absoluteUrl)}"${srcSetAttr}${sizesAttr}${altAttr} style="max-width:100%;" loading="lazy" decoding="async" />`;
+    // Inject/replace srcset and sizes in-place
+    if (srcSetUrls) {
+      newImgTag = setAttribute(newImgTag, 'srcset', srcSetUrls);
+      newImgTag = setAttribute(newImgTag, 'sizes', `(max-width: ${largestWidth}px) 100vw, ${largestWidth}px`);
+    }
+
+    // Append/merge style style="max-width: 100%;"
+    if (/style=["']/i.test(newImgTag)) {
+      newImgTag = newImgTag.replace(/style=["']([^"']*)["']/i, (m, p1) => {
+        const trimmed = p1.trim();
+        const separator = trimmed.endsWith(';') || trimmed === '' ? '' : ';';
+        return `style="${p1}${separator}max-width:100%;"`;
+      });
+    } else {
+      newImgTag = newImgTag.replace(/(<img\b)/i, '$1 style="max-width:100%;"');
+    }
+
+    // Append loading="lazy" if not present
+    if (!/loading=["']/i.test(newImgTag)) {
+      newImgTag = newImgTag.replace(/(<img\b)/i, '$1 loading="lazy"');
+    }
+
+    // Append decoding="async" if not present
+    if (!/decoding=["']/i.test(newImgTag)) {
+      newImgTag = newImgTag.replace(/(<img\b)/i, '$1 decoding="async"');
+    }
 
     processedHtml = processedHtml.replaceAll(fullMatch, newImgTag);
   }
 
   return processedHtml;
+}
+
+/**
+ * Helper to inject or update an attribute inside an HTML tag.
+ * Inserts the attribute right after '<img' to ensure self-closing tags are not broken.
+ */
+function setAttribute(tag: string, name: string, value: string): string {
+  const regex = new RegExp(`${name}=["']([^"']*)["']`, 'i');
+  if (regex.test(tag)) {
+    return tag.replace(regex, `${name}="${value}"`);
+  }
+  return tag.replace(/(<img\b)/i, `$1 ${name}="${value}"`);
 }
 
 /**
@@ -221,8 +261,29 @@ export async function pushToWordPress({
       const fileContent = await readFile(post.localPath, 'utf-8');
       const { content: markdownBody } = matter(fileContent);
 
-      // Strip first H1 from markdown to avoid duplicated titles
-      const bodyWithoutTitle = markdownBody.replace(/^#\s+.+$/m, '').trim();
+      // Strip first H1 from markdown to avoid duplicated titles, only if it's the first non-empty line of the document and not inside a code block
+      const lines = markdownBody.split('\n');
+      let inCodeBlock = false;
+      let firstH1Index = -1;
+      
+      for (let i = 0; i < lines.length; i++) {
+        const trimmed = lines[i].trim();
+        if (trimmed.startsWith('```')) {
+          inCodeBlock = !inCodeBlock;
+        }
+        if (!inCodeBlock && trimmed.startsWith('# ')) {
+          firstH1Index = i;
+          break;
+        }
+      }
+
+      if (firstH1Index !== -1) {
+        const hasContentBefore = lines.slice(0, firstH1Index).some(line => line.trim() !== '');
+        if (!hasContentBefore) {
+          lines.splice(firstH1Index, 1);
+        }
+      }
+      const bodyWithoutTitle = lines.join('\n').trim();
 
       // Render Markdown content to HTML
       let htmlContent = await renderMarkdownContent({
@@ -245,11 +306,14 @@ export async function pushToWordPress({
         sizes,
       });
 
+      // Replace slashes with hyphens to match WordPress's sanitization behavior
+      const wpSlug = post.slug.replace(/\//g, '-');
+
       // Search WordPress to see if the post already exists by slug
       const existingPosts = await wpFetch({
         endpoint,
         credentials,
-        path: `/wp/v2/posts?slug=${encodeURIComponent(post.slug)}&status=any`,
+        path: `/wp/v2/posts?slug=${encodeURIComponent(wpSlug)}&status=any`,
       });
 
       const wpPostExists = existingPosts && existingPosts.length > 0;
@@ -258,7 +322,7 @@ export async function pushToWordPress({
       const payload = {
         title: post.title,
         content: htmlContent,
-        slug: post.slug,
+        slug: wpSlug,
         status: 'publish',
         date: post.date,
       };
@@ -290,8 +354,9 @@ export async function pushToWordPress({
           console.log(`  ✅ Successfully CREATED new WordPress post (ID: ${newPost.id})`);
         }
       }
-    } catch (err: any) {
-      console.error(`  ❌ Failed to sync post "${post.title}":`, err.message);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      console.error(`  ❌ Failed to sync post "${post.title}":`, errMsg);
       // We don't want to crash the whole sync if one post fails, but if single post targeted, we bubble up
       if (targetPostSlug) {
         throw err;

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -1,0 +1,272 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import matter from 'gray-matter';
+import { exists } from './files';
+import { Site, Registry } from '../../src/domain/registry';
+import { VaultDirectoryIndex } from '../../src/lib/vault';
+import { renderMarkdownContent } from '../../src/lib/markdown';
+import { getThumbnailPath, normalizeThumbnailSizes } from '../../src/lib/responsive-images';
+
+interface PushToWordPressArgs {
+  site: Site;
+  registry: Registry;
+  allIndices: Map<string, VaultDirectoryIndex>;
+  targetPostSlug?: string;
+  dryRun: boolean;
+}
+
+interface WpFetchArgs {
+  endpoint: string;
+  credentials: { username: string; applicationPassword: string };
+  path: string;
+  method?: string;
+  body?: any;
+}
+
+/**
+ * Performs authenticated requests to the WordPress REST API.
+ */
+async function wpFetch({
+  endpoint,
+  credentials,
+  path: apiPath,
+  method = 'GET',
+  body,
+}: WpFetchArgs) {
+  const url = `${endpoint.replace(/\/+$/, '')}${apiPath}`;
+  const auth = Buffer.from(`${credentials.username}:${credentials.applicationPassword}`).toString('base64');
+  
+  const headers: Record<string, string> = {
+    'Authorization': `Basic ${auth}`,
+  };
+
+  if (body) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`WordPress API error (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Parses HTML and replaces all local image source references with their absolute 
+ * URL on the designated image host, utilizing the largest generated thumbnail size.
+ */
+export async function replaceLocalImagesWithThumbnails({
+  html,
+  site,
+  registry,
+  sizes,
+}: {
+  html: string;
+  site: Site;
+  registry: Registry;
+  sizes: readonly number[];
+}): Promise<string> {
+  const imageHost = site.imageHost || registry.imageHost;
+  const largestWidth = sizes[sizes.length - 1];
+
+  if (!largestWidth) {
+    return html;
+  }
+
+  const imgRegex = /<img\s+([^>]*src=["']([^"']+)["'][^>]*?)>/gi;
+  const matches: { fullMatch: string; src: string }[] = [];
+  let match;
+  while ((match = imgRegex.exec(html)) !== null) {
+    matches.push({ fullMatch: match[0], src: match[2] });
+  }
+
+  let processedHtml = html;
+
+  for (const { fullMatch, src } of matches) {
+    // Skip external or inline assets
+    if (
+      src.startsWith('http://') ||
+      src.startsWith('https://') ||
+      src.startsWith('data:') ||
+      src.startsWith('#')
+    ) {
+      continue;
+    }
+
+    const cleanSrc = src.replace(/^\//, '');
+    const decodedSrc = decodeURIComponent(cleanSrc);
+
+    // Get the thumbnail filename and relative directory path
+    const thumbPath = getThumbnailPath({ imagePath: decodedSrc, width: largestWidth });
+
+    // Determine target location in S3 by checking local filesystem existence
+    const contentThumbPath = path.join(site.vaultPath, 'content', thumbPath);
+    const publicThumbPath = path.join(site.vaultPath, 'public', thumbPath);
+
+    let s3SubDir = 'content';
+    if (await exists(publicThumbPath)) {
+      s3SubDir = 'public';
+    } else if (await exists(contentThumbPath)) {
+      s3SubDir = 'content';
+    }
+
+    // Build the absolute URL on the configured imageHost
+    let absoluteUrl: string;
+    if (imageHost) {
+      absoluteUrl = `${imageHost.replace(/\/+$/, '')}/${s3SubDir}/${thumbPath}`;
+    } else {
+      absoluteUrl = `https://${site.domain || 'localhost'}/api/vault-public/${thumbPath}`;
+    }
+
+    // Preserve the alt text attribute if present
+    const altMatch = fullMatch.match(/alt=["']([^"']*)["']/i);
+    const altAttr = altMatch ? ` alt="${altMatch[1]}"` : '';
+    const newImgTag = `<img src="${encodeURI(absoluteUrl)}"${altAttr} />`;
+
+    processedHtml = processedHtml.replaceAll(fullMatch, newImgTag);
+  }
+
+  return processedHtml;
+}
+
+/**
+ * Iterates through the Markdown posts in the vault and publishes them to WordPress.
+ */
+export async function pushToWordPress({
+  site,
+  registry,
+  allIndices,
+  targetPostSlug,
+  dryRun,
+}: PushToWordPressArgs) {
+  const credentials = site.wordpress;
+  if (!credentials) {
+    throw new Error(`⨯ WordPress credentials are not configured for site [${site.siteId}].`);
+  }
+
+  const endpoint = credentials.endpoint || `https://${site.domain}/wp-json`;
+  const sizes = normalizeThumbnailSizes(site.thumbnailSizes || registry.thumbnailSizes);
+
+  console.log(`\n📝 Preparing WordPress Publishing...`);
+  console.log(`- Target Endpoint: ${endpoint}`);
+  console.log(`- Authenticated As: ${credentials.username}`);
+  if (targetPostSlug) {
+    console.log(`- Target Single Post: ${targetPostSlug}`);
+  }
+  console.log(dryRun ? `- Mode: DRY RUN (No changes will be written)\n` : `- Mode: Live Sync\n`);
+
+  // Collect all posts from directory indices
+  const postsToPublish: { localPath: string; slug: string; title: string; date: string }[] = [];
+
+  for (const [dirKey, dirIndex] of allIndices.entries()) {
+    for (const page of dirIndex.pages) {
+      // Build the full hierarchical slug
+      const fullSlug = dirKey ? `${dirKey}/${page.slug}` : page.slug;
+
+      // Filter by target post slug if specified
+      if (targetPostSlug && fullSlug !== targetPostSlug) {
+        continue;
+      }
+
+      const localPath = path.join(site.vaultPath, 'content', dirKey, `${page.slug}.md`);
+      postsToPublish.push({
+        localPath,
+        slug: fullSlug,
+        title: page.title,
+        date: page.date,
+      });
+    }
+  }
+
+  if (targetPostSlug && postsToPublish.length === 0) {
+    throw new Error(`⨯ Could not find any post in the vault matching slug: "${targetPostSlug}"`);
+  }
+
+  console.log(`Found ${postsToPublish.length} post(s) to process.`);
+
+  for (const post of postsToPublish) {
+    try {
+      console.log(`\nSyncing "${post.title}" (slug: ${post.slug})...`);
+
+      // Read markdown and parse frontmatter
+      const fileContent = await readFile(post.localPath, 'utf-8');
+      const { content: markdownBody } = matter(fileContent);
+
+      // Strip first H1 from markdown to avoid duplicated titles
+      const bodyWithoutTitle = markdownBody.replace(/^#\s+.+$/m, '').trim();
+
+      // Render Markdown content to HTML
+      let htmlContent = await renderMarkdownContent({
+        markdown: bodyWithoutTitle,
+        thumbnailSizes: sizes,
+      });
+
+      // Replace local image paths with imageHost absolute thumbnail URLs
+      htmlContent = await replaceLocalImagesWithThumbnails({
+        html: htmlContent,
+        site,
+        registry,
+        sizes,
+      });
+
+      // Search WordPress to see if the post already exists by slug
+      const existingPosts = await wpFetch({
+        endpoint,
+        credentials,
+        path: `/wp/v2/posts?slug=${encodeURIComponent(post.slug)}&status=any`,
+      });
+
+      const wpPostExists = existingPosts && existingPosts.length > 0;
+      const wpPostId = wpPostExists ? existingPosts[0].id : null;
+
+      const payload = {
+        title: post.title,
+        content: htmlContent,
+        slug: post.slug,
+        status: 'publish',
+        date: post.date,
+      };
+
+      if (wpPostExists) {
+        if (dryRun) {
+          console.log(`  [DRY RUN] Would UPDATE WordPress post "${post.title}" (ID: ${wpPostId})`);
+        } else {
+          await wpFetch({
+            endpoint,
+            credentials,
+            path: `/wp/v2/posts/${wpPostId}`,
+            method: 'POST',
+            body: payload,
+          });
+          console.log(`  ✅ Successfully UPDATED WordPress post (ID: ${wpPostId})`);
+        }
+      } else {
+        if (dryRun) {
+          console.log(`  [DRY RUN] Would CREATE new WordPress post "${post.title}"`);
+        } else {
+          const newPost = await wpFetch({
+            endpoint,
+            credentials,
+            path: `/wp/v2/posts`,
+            method: 'POST',
+            body: payload,
+          });
+          console.log(`  ✅ Successfully CREATED new WordPress post (ID: ${newPost.id})`);
+        }
+      }
+    } catch (err: any) {
+      console.error(`  ❌ Failed to sync post "${post.title}":`, err.message);
+      // We don't want to crash the whole sync if one post fails, but if single post targeted, we bubble up
+      if (targetPostSlug) {
+        throw err;
+      }
+    }
+  }
+}

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -1,8 +1,7 @@
 import { resolveVaultRequest } from "@/lib/vault";
 import { env } from "@/lib/env";
 import { INDEX_SLUG } from "@/lib/constants";
-import { remark } from "remark";
-import html from "remark-html";
+import { renderMarkdownContent } from "@/lib/markdown";
 import matter from "gray-matter";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
@@ -69,8 +68,10 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
     // Strip the first H1 from the body if it exists, to avoid double titles
     const bodyWithoutTitle = markdownBody.replace(/^#\s+.+$/m, "").trim();
 
-    const processedContent = await remark().use(html).process(bodyWithoutTitle);
-    const contentHtml = processedContent.toString();
+    const contentHtml = await renderMarkdownContent({
+      markdown: bodyWithoutTitle,
+      thumbnailSizes: result.thumbnailSizes,
+    });
     const { metadata } = result;
 
     const publishedDate = new Date(metadata.date);

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { resolveVaultRequest } from "@/lib/vault";
+import { resolveVaultRequest, fetchRootIndex } from "@/lib/vault";
 import { env } from "@/lib/env";
 import { INDEX_SLUG } from "@/lib/constants";
 import { renderMarkdownContent } from "@/lib/markdown";
@@ -68,9 +68,13 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
     // Strip the first H1 from the body if it exists, to avoid double titles
     const bodyWithoutTitle = markdownBody.replace(/^#\s+.+$/m, "").trim();
 
+    const rootIndex = await fetchRootIndex(vaultConfig);
+    const publicFiles = rootIndex?.publicFiles || [];
+
     const contentHtml = await renderMarkdownContent({
       markdown: bodyWithoutTitle,
       thumbnailSizes: result.thumbnailSizes,
+      publicFiles,
     });
     const { metadata } = result;
 

--- a/src/app/api/vault-public/[...path]/route.ts
+++ b/src/app/api/vault-public/[...path]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { S3Client, GetObjectCommand, type GetObjectCommandOutput } from "@aws-sdk/client-s3";
 import { getRegistry } from "@/lib/registry";
 import { env } from "@/lib/env";
 
@@ -66,16 +66,19 @@ export async function GET(
 
   try {
     const client = await getS3Client();
-    const key = `${vaultRoot}/public/${filePath}`;
+    const candidateKeys = [`${vaultRoot}/public/${filePath}`, `${vaultRoot}/content/${filePath}`];
+    let response: GetObjectCommandOutput | null = null;
 
-    const command = new GetObjectCommand({
-      Bucket: bucketName,
-      Key: key,
-    });
+    for (const key of candidateKeys) {
+      try {
+        response = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: key }));
+        break;
+      } catch {
+        response = null;
+      }
+    }
 
-    const response = await client.send(command);
-
-    if (!response.Body) {
+    if (!response || !response.Body) {
       return new NextResponse("Not Found", { status: 404 });
     }
 
@@ -87,7 +90,7 @@ export async function GET(
         "Cache-Control": "public, max-age=31536000, immutable",
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     // Fallback logic for critical system files like favicon.ico
     if (filePath === "favicon.ico") {
       const url = new URL(_request.url);
@@ -96,7 +99,8 @@ export async function GET(
       return NextResponse.redirect(url);
     }
 
-    console.error(`Error serving vault public file [${filePath}]:`, error.message);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error serving vault public file [${filePath}]:`, message);
     return new NextResponse("Not Found", { status: 404 });
   }
 }

--- a/src/domain/registry.ts
+++ b/src/domain/registry.ts
@@ -2,6 +2,12 @@ import { z } from 'zod';
 
 export const ThumbnailSizesSchema = z.array(z.number().int().positive()).min(1).optional();
 
+export const WordPressCredentialsSchema = z.object({
+  username: z.string(),
+  applicationPassword: z.string(),
+  endpoint: z.string().url().optional(),
+});
+
 export const SiteSchema = z.object({
   domain: z.string().optional(),
   siteId: z.string(),
@@ -10,6 +16,8 @@ export const SiteSchema = z.object({
   vercelProjectId: z.string().optional(),
   endpoint: z.string().url().optional(),
   thumbnailSizes: ThumbnailSizesSchema,
+  wordpress: WordPressCredentialsSchema.optional(),
+  imageHost: z.string().url().optional(),
 });
 
 export const RegistrySchema = z.object({
@@ -17,8 +25,10 @@ export const RegistrySchema = z.object({
   accessKeyId: z.string().optional(),
   secretAccessKey: z.string().optional(),
   thumbnailSizes: ThumbnailSizesSchema,
+  imageHost: z.string().url().optional(),
   sites: z.array(SiteSchema),
 });
 
 export type Site = z.infer<typeof SiteSchema>;
 export type Registry = z.infer<typeof RegistrySchema>;
+

--- a/src/domain/registry.ts
+++ b/src/domain/registry.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const ThumbnailSizesSchema = z.array(z.number().int().positive()).min(1).optional();
+
 export const SiteSchema = z.object({
   domain: z.string().optional(),
   siteId: z.string(),
@@ -7,12 +9,14 @@ export const SiteSchema = z.object({
   bucketName: z.string().optional(),
   vercelProjectId: z.string().optional(),
   endpoint: z.string().url().optional(),
+  thumbnailSizes: ThumbnailSizesSchema,
 });
 
 export const RegistrySchema = z.object({
   endpoint: z.string().url().optional(),
   accessKeyId: z.string().optional(),
   secretAccessKey: z.string().optional(),
+  thumbnailSizes: ThumbnailSizesSchema,
   sites: z.array(SiteSchema),
 });
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -31,3 +31,13 @@ export const SITEMAP_PAGES_XML = 'sitemap_pages.xml';
  * The default filename for the registry configuration.
  */
 export const DEFAULT_REGISTRY_FILENAME = 'registry.json';
+
+/**
+ * Generated responsive image thumbnail directory.
+ */
+export const THUMBNAILS_DIR = '_thumbnails';
+
+/**
+ * Default responsive image widths, in pixels.
+ */
+export const DEFAULT_THUMBNAIL_SIZES = [320, 640, 960, 1280] as const;

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -40,9 +40,22 @@ describe("createMarkdownRenderer", () => {
       thumbnailSizes: [320],
       publicFiles: ["image.png"],
     });
-    expect(html).toContain('<figure class="wp-block-image">');
+    expect(html).toContain('<figure class="image-figure">');
     expect(html).toContain('<img src="/image.png" alt="My Alt Text"');
     expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
+  });
+
+  it("separates block-level images from adjacent text blocks", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: "Some text before\n![My Alt Text](image.png)\nSome text after",
+      thumbnailSizes: [320],
+      publicFiles: ["image.png"],
+    });
+    expect(html).toContain("<p>Some text before</p>");
+    expect(html).toContain('<figure class="image-figure">');
+    expect(html).toContain('<img src="/image.png" alt="My Alt Text"');
+    expect(html).toContain("<p>Some text after</p>");
   });
 });
 

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -58,6 +58,18 @@ describe("createMarkdownRenderer", () => {
     expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain("<p>Some text after</p>");
   });
+
+  it("renders images with surrounding whitespace or newlines inside paragraphs wrapped in figure", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: "  ![My Alt Text](image.png) \n ",
+      thumbnailSizes: [320],
+      publicFiles: ["image.png"],
+    });
+    expect(html).toContain('<figure class="image-figure">');
+    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
+    expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
+  });
 });
 
 describe("preprocessWikilinks", () => {

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -32,6 +32,18 @@ describe("createMarkdownRenderer", () => {
     });
     await expect(renderer.renderMarkdownContent({ markdown: "![alt](image.png)", thumbnailSizes: [320] })).resolves.toBe("rendered");
   });
+
+  it("renders standard markdown images as HTML wrapped in figure and figcaption", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: "![My Alt Text](image.png)",
+      thumbnailSizes: [320],
+      publicFiles: ["image.png"],
+    });
+    expect(html).toContain('<figure class="wp-block-image">');
+    expect(html).toContain('<img src="/image.png" alt="My Alt Text"');
+    expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
+  });
 });
 
 describe("preprocessWikilinks", () => {

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMarkdownRenderer, type MarkdownNode } from "./markdown";
+
+describe("createMarkdownRenderer", () => {
+  it("injects responsive image attributes into image nodes before processing", async () => {
+    const renderer = createMarkdownRenderer({
+      getResponsiveImageAttributes: vi.fn(() => ({
+        src: "/image.png",
+        srcSet: "/_thumbnails/image-320.webp 320w",
+        sizes: "100vw",
+      })),
+      processMarkdown: async () => "rendered",
+    });
+    const tree: MarkdownNode = {
+      type: "root",
+      children: [
+        {
+          type: "image",
+          url: "image.png",
+        },
+      ],
+    };
+
+    renderer.applyResponsiveImages({ tree, thumbnailSizes: [320] });
+
+    expect(tree.children?.[0].data?.hProperties).toEqual({
+      src: "/image.png",
+      srcset: "/_thumbnails/image-320.webp 320w",
+      sizes: "100vw",
+      loading: "lazy",
+      decoding: "async",
+    });
+    await expect(renderer.renderMarkdownContent({ markdown: "![alt](image.png)", thumbnailSizes: [320] })).resolves.toBe("rendered");
+  });
+});

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createMarkdownRenderer, type MarkdownNode } from "./markdown";
+import { createMarkdownRenderer, type MarkdownNode, preprocessWikilinks } from "./markdown";
 
 describe("createMarkdownRenderer", () => {
   it("injects responsive image attributes into image nodes before processing", async () => {
@@ -33,3 +33,14 @@ describe("createMarkdownRenderer", () => {
     await expect(renderer.renderMarkdownContent({ markdown: "![alt](image.png)", thumbnailSizes: [320] })).resolves.toBe("rendered");
   });
 });
+
+describe("preprocessWikilinks", () => {
+
+  it("converts Obsidian wikilinks to standard markdown image tags using publicFiles", () => {
+    const markdown = "Hello ![[screenshot.png]] and ![[screenshot.png|My Alt Text]]";
+    const publicFiles = ["attachments/screenshot.png"];
+    const result = preprocessWikilinks(markdown, publicFiles);
+    expect(result).toBe("Hello ![](/attachments/screenshot.png) and ![My Alt Text](/attachments/screenshot.png)");
+  });
+});
+

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -27,6 +27,7 @@ describe("createMarkdownRenderer", () => {
       src: "/image.png",
       srcset: "/_thumbnails/image-320.webp 320w",
       sizes: "100vw",
+      style: "max-width: 100%;",
       loading: "lazy",
       decoding: "async",
     });
@@ -41,7 +42,7 @@ describe("createMarkdownRenderer", () => {
       publicFiles: ["image.png"],
     });
     expect(html).toContain('<figure class="image-figure">');
-    expect(html).toContain('<img src="/image.png" alt="My Alt Text"');
+    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
   });
 
@@ -54,7 +55,7 @@ describe("createMarkdownRenderer", () => {
     });
     expect(html).toContain("<p>Some text before</p>");
     expect(html).toContain('<figure class="image-figure">');
-    expect(html).toContain('<img src="/image.png" alt="My Alt Text"');
+    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain("<p>Some text after</p>");
   });
 });

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -35,12 +35,11 @@ describe("createMarkdownRenderer", () => {
 });
 
 describe("preprocessWikilinks", () => {
-
   it("converts Obsidian wikilinks to standard markdown image tags using publicFiles", () => {
     const markdown = "Hello ![[screenshot.png]] and ![[screenshot.png|My Alt Text]]";
     const publicFiles = ["attachments/screenshot.png"];
     const result = preprocessWikilinks(markdown, publicFiles);
-    expect(result).toBe("Hello ![](/attachments/screenshot.png) and ![My Alt Text](/attachments/screenshot.png)");
+    expect(result).toBe("Hello ![](</attachments/screenshot.png>) and ![My Alt Text](</attachments/screenshot.png>)");
   });
 });
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -53,8 +53,12 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       : { class: "image-figure" };
 
     function visit(node: MarkdownNode) {
-      if (node.type === "paragraph" && node.children && node.children.length === 1 && node.children[0].type === "image") {
-        const imgNode = node.children[0];
+      const nonWhitespaceChildren = node.children?.filter(
+        child => !(child.type === "text" && child.value?.trim() === "")
+      ) || [];
+
+      if (node.type === "paragraph" && nonWhitespaceChildren.length === 1 && nonWhitespaceChildren[0].type === "image") {
+        const imgNode = nonWhitespaceChildren[0];
         const imgUrl = imgNode.url || "";
         const attributes = deps.getResponsiveImageAttributes({ src: imgUrl, thumbnailSizes });
         const srcVal = attributes ? attributes.src : encodeURI(imgUrl);

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,7 +1,7 @@
 import { remark } from "remark";
 import html from "remark-html";
 import type { Plugin } from "unified";
-import { getResponsiveImageAttributes } from "./responsive-images";
+import { getResponsiveImageAttributes, normalizeThumbnailSizes } from "./responsive-images";
 
 export type MarkdownNode = {
   type: "root" | "paragraph" | "image" | "image-figure" | "element" | "text" | "html" | (string & {});
@@ -30,8 +30,28 @@ export type MarkdownRendererDeps = {
   processMarkdown: ({ markdown, plugin }: { markdown: string; plugin: Plugin<[], MarkdownNode> }) => Promise<string>;
 };
 
+export function ensureImageBlockSeparation(markdown: string): string {
+  // Matches markdown images that occupy a single line on their own (with optional spaces/tabs)
+  // E.g., `![alt](url)` or standard markdown links
+  return markdown.replace(/(?:^|\n)([ \t]*!\[[^\]]*\]\([^)]+\)[ \t]*)(?=\n|$)/g, '\n\n$1\n\n');
+}
+
 export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
-  function applyResponsiveImages({ tree, thumbnailSizes }: { tree: MarkdownNode; thumbnailSizes: readonly number[] }) {
+  function applyResponsiveImages({
+    tree,
+    thumbnailSizes,
+    getFigureProperties,
+  }: {
+    tree: MarkdownNode;
+    thumbnailSizes: readonly number[];
+    getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
+  }) {
+    const normalizedSizes = normalizeThumbnailSizes(thumbnailSizes);
+    const largestWidth = normalizedSizes[normalizedSizes.length - 1] || 768;
+    const figureProps = getFigureProperties
+      ? getFigureProperties(largestWidth)
+      : { class: "image-figure" };
+
     function visit(node: MarkdownNode) {
       if (node.type === "paragraph" && node.children && node.children.length === 1 && node.children[0].type === "image") {
         const imgNode = node.children[0];
@@ -48,7 +68,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
         }
         if (attributes) {
           imgProperties.srcset = attributes.srcSet;
-          imgProperties.sizes = attributes.sizes;
+          imgProperties.sizes = `(max-width: ${largestWidth}px) 100vw, ${largestWidth}px`;
         }
         imgProperties.loading = "lazy";
         imgProperties.decoding = "async";
@@ -81,7 +101,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
           ...node.data,
           hName: "figure",
           hProperties: {
-            class: "wp-block-image",
+            ...figureProps,
           },
           hChildren: children,
         };
@@ -114,10 +134,16 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
     visit(tree);
   }
 
-  function responsiveImagePlugin({ thumbnailSizes }: { thumbnailSizes: readonly number[] }): Plugin<[], MarkdownNode> {
+  function responsiveImagePlugin({
+    thumbnailSizes,
+    getFigureProperties,
+  }: {
+    thumbnailSizes: readonly number[];
+    getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
+  }): Plugin<[], MarkdownNode> {
     return function transformResponsiveImages() {
       return function transformer(tree: MarkdownNode) {
-        applyResponsiveImages({ tree, thumbnailSizes });
+        applyResponsiveImages({ tree, thumbnailSizes, getFigureProperties });
       };
     };
   }
@@ -129,15 +155,18 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       markdown,
       thumbnailSizes,
       publicFiles,
+      getFigureProperties,
     }: {
       markdown: string;
       thumbnailSizes: readonly number[];
       publicFiles?: readonly string[];
+      getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
     }): Promise<string> {
-      const preprocessed = publicFiles ? preprocessWikilinks(markdown, publicFiles) : markdown;
+      let preprocessed = publicFiles ? preprocessWikilinks(markdown, publicFiles) : markdown;
+      preprocessed = ensureImageBlockSeparation(preprocessed);
       return deps.processMarkdown({
         markdown: preprocessed,
-        plugin: responsiveImagePlugin({ thumbnailSizes }),
+        plugin: responsiveImagePlugin({ thumbnailSizes, getFigureProperties }),
       });
     },
   };

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -4,10 +4,17 @@ import type { Plugin } from "unified";
 import { getResponsiveImageAttributes } from "./responsive-images";
 
 export type MarkdownNode = {
-  type: string;
+  type: "root" | "paragraph" | "image" | "image-figure" | "element" | "text" | "html" | (string & {});
   url?: string;
+  alt?: string;
+  title?: string;
+  value?: string;
+  tagName?: string;
+  properties?: Record<string, string | number | boolean>;
   data?: {
-    hProperties?: Record<string, string>;
+    hName?: string;
+    hProperties?: Record<string, string | number | boolean>;
+    hChildren?: MarkdownNode[];
   };
   children?: MarkdownNode[];
 };
@@ -26,6 +33,62 @@ export type MarkdownRendererDeps = {
 export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
   function applyResponsiveImages({ tree, thumbnailSizes }: { tree: MarkdownNode; thumbnailSizes: readonly number[] }) {
     function visit(node: MarkdownNode) {
+      if (node.type === "paragraph" && node.children && node.children.length === 1 && node.children[0].type === "image") {
+        const imgNode = node.children[0];
+        const imgUrl = imgNode.url || "";
+        const attributes = deps.getResponsiveImageAttributes({ src: imgUrl, thumbnailSizes });
+        const srcVal = attributes ? attributes.src : encodeURI(imgUrl);
+        const altText = imgNode.alt || '';
+
+        const imgProperties: Record<string, string> = {
+          src: srcVal,
+        };
+        if (altText) {
+          imgProperties.alt = altText;
+        }
+        if (attributes) {
+          imgProperties.srcset = attributes.srcSet;
+          imgProperties.sizes = attributes.sizes;
+        }
+        imgProperties.loading = "lazy";
+        imgProperties.decoding = "async";
+
+        const children: MarkdownNode[] = [
+          {
+            type: "element",
+            tagName: "img",
+            properties: imgProperties,
+            children: [],
+          }
+        ];
+
+        if (altText) {
+          children.push({
+            type: "element",
+            tagName: "figcaption",
+            properties: {},
+            children: [
+              {
+                type: "text",
+                value: altText,
+              }
+            ],
+          });
+        }
+
+        node.type = "image-figure";
+        node.data = {
+          ...node.data,
+          hName: "figure",
+          hProperties: {
+            class: "wp-block-image",
+          },
+          hChildren: children,
+        };
+        delete node.children;
+        return;
+      }
+
       if (node.type === "image" && node.url) {
         const attributes = deps.getResponsiveImageAttributes({ src: node.url, thumbnailSizes });
         if (attributes) {
@@ -111,7 +174,7 @@ export function preprocessWikilinks(markdown: string, publicFiles: readonly stri
 const defaultMarkdownRenderer = createMarkdownRenderer({
   getResponsiveImageAttributes,
   processMarkdown: async ({ markdown, plugin }) => {
-    const processedContent = await remark().use(plugin).use(html).process(markdown);
+    const processedContent = await remark().use(plugin).use(html, { sanitize: false }).process(markdown);
     return processedContent.toString();
   },
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -62,6 +62,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
 
         const imgProperties: Record<string, string> = {
           src: srcVal,
+          style: "max-width: 100%;",
         };
         if (altText) {
           imgProperties.alt = altText;
@@ -119,6 +120,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
               src: attributes.src,
               srcset: attributes.srcSet,
               sizes: attributes.sizes,
+              style: "max-width: 100%;",
               loading: "lazy",
               decoding: "async",
             },

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -101,7 +101,7 @@ export function preprocessWikilinks(markdown: string, publicFiles: readonly stri
     });
 
     if (resolvedPath) {
-      return `![${alt}](/${resolvedPath})`;
+      return `![${alt}](</${resolvedPath}>)`;
     }
 
     return match;

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,90 @@
+import { remark } from "remark";
+import html from "remark-html";
+import type { Plugin } from "unified";
+import { getResponsiveImageAttributes } from "./responsive-images";
+
+export type MarkdownNode = {
+  type: string;
+  url?: string;
+  data?: {
+    hProperties?: Record<string, string>;
+  };
+  children?: MarkdownNode[];
+};
+
+export type MarkdownRendererDeps = {
+  getResponsiveImageAttributes: ({
+    src,
+    thumbnailSizes,
+  }: {
+    src: string;
+    thumbnailSizes: readonly number[];
+  }) => { src: string; srcSet: string; sizes: string } | null;
+  processMarkdown: ({ markdown, plugin }: { markdown: string; plugin: Plugin<[], MarkdownNode> }) => Promise<string>;
+};
+
+export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
+  function applyResponsiveImages({ tree, thumbnailSizes }: { tree: MarkdownNode; thumbnailSizes: readonly number[] }) {
+    function visit(node: MarkdownNode) {
+      if (node.type === "image" && node.url) {
+        const attributes = deps.getResponsiveImageAttributes({ src: node.url, thumbnailSizes });
+        if (attributes) {
+          node.data = {
+            ...node.data,
+            hProperties: {
+              ...node.data?.hProperties,
+              src: attributes.src,
+              srcset: attributes.srcSet,
+              sizes: attributes.sizes,
+              loading: "lazy",
+              decoding: "async",
+            },
+          };
+        }
+      }
+
+      for (const child of node.children || []) {
+        visit(child);
+      }
+    }
+
+    visit(tree);
+  }
+
+  function responsiveImagePlugin({ thumbnailSizes }: { thumbnailSizes: readonly number[] }): Plugin<[], MarkdownNode> {
+    return function transformResponsiveImages() {
+      return function transformer(tree: MarkdownNode) {
+        applyResponsiveImages({ tree, thumbnailSizes });
+      };
+    };
+  }
+
+  return {
+    applyResponsiveImages,
+    responsiveImagePlugin,
+    renderMarkdownContent({
+      markdown,
+      thumbnailSizes,
+    }: {
+      markdown: string;
+      thumbnailSizes: readonly number[];
+    }): Promise<string> {
+      return deps.processMarkdown({
+        markdown,
+        plugin: responsiveImagePlugin({ thumbnailSizes }),
+      });
+    },
+  };
+}
+
+const defaultMarkdownRenderer = createMarkdownRenderer({
+  getResponsiveImageAttributes,
+  processMarkdown: async ({ markdown, plugin }) => {
+    const processedContent = await remark().use(plugin).use(html).process(markdown);
+    return processedContent.toString();
+  },
+});
+
+export const responsiveImagePlugin = defaultMarkdownRenderer.responsiveImagePlugin;
+export const applyResponsiveImages = defaultMarkdownRenderer.applyResponsiveImages;
+export const renderMarkdownContent = defaultMarkdownRenderer.renderMarkdownContent;

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -65,16 +65,47 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
     renderMarkdownContent({
       markdown,
       thumbnailSizes,
+      publicFiles,
     }: {
       markdown: string;
       thumbnailSizes: readonly number[];
+      publicFiles?: readonly string[];
     }): Promise<string> {
+      const preprocessed = publicFiles ? preprocessWikilinks(markdown, publicFiles) : markdown;
       return deps.processMarkdown({
-        markdown,
+        markdown: preprocessed,
         plugin: responsiveImagePlugin({ thumbnailSizes }),
       });
     },
   };
+}
+
+export function preprocessWikilinks(markdown: string, publicFiles: readonly string[]): string {
+  const wikilinkRegex = /!\[\[([^\]]+)\]\]/g;
+  return markdown.replace(wikilinkRegex, (match, content) => {
+    const parts = content.split('|');
+    const filename = parts[0].trim();
+
+    let alt = '';
+    for (let i = 1; i < parts.length; i++) {
+      const part = parts[i].trim();
+      if (!/^\d+$/.test(part)) {
+        alt = part;
+      }
+    }
+
+    const normalizedFilename = filename.toLowerCase();
+    const resolvedPath = publicFiles.find((file) => {
+      const base = file.split('/').pop()?.toLowerCase();
+      return base === normalizedFilename;
+    });
+
+    if (resolvedPath) {
+      return `![${alt}](/${resolvedPath})`;
+    }
+
+    return match;
+  });
 }
 
 const defaultMarkdownRenderer = createMarkdownRenderer({
@@ -88,3 +119,4 @@ const defaultMarkdownRenderer = createMarkdownRenderer({
 export const responsiveImagePlugin = defaultMarkdownRenderer.responsiveImagePlugin;
 export const applyResponsiveImages = defaultMarkdownRenderer.applyResponsiveImages;
 export const renderMarkdownContent = defaultMarkdownRenderer.renderMarkdownContent;
+

--- a/src/lib/responsive-images.test.ts
+++ b/src/lib/responsive-images.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import path from "path";
+import { createResponsiveImageHelpers } from "./responsive-images";
+
+describe("createResponsiveImageHelpers", () => {
+  const helpers = createResponsiveImageHelpers({
+    defaultThumbnailSizes: [640, 320, 640],
+    generatedThumbnailDir: "_thumbnails",
+    responsiveImageSizes: "100vw",
+    supportedImageExtensions: new Set([".png", ".jpg"]),
+    extname: path.posix.extname,
+    parsePosixPath: path.posix.parse,
+    encodeUri: encodeURI,
+  });
+
+  it("normalizes thumbnail sizes", () => {
+    expect(helpers.normalizeThumbnailSizes(undefined)).toEqual([320, 640]);
+    expect(helpers.normalizeThumbnailSizes([800, -1, 400, 400])).toEqual([400, 800]);
+  });
+
+  it("builds encoded responsive image attributes", () => {
+    expect(
+      helpers.getResponsiveImageAttributes({
+        src: "/attachments/截圖 2026.png",
+        thumbnailSizes: [320, 640],
+      })
+    ).toEqual({
+      src: "/attachments/%E6%88%AA%E5%9C%96%202026.png",
+      srcSet:
+        "/_thumbnails/attachments/%E6%88%AA%E5%9C%96%202026-320.webp 320w, /_thumbnails/attachments/%E6%88%AA%E5%9C%96%202026-640.webp 640w",
+      sizes: "100vw",
+    });
+  });
+
+  it("skips remote and generated thumbnail sources", () => {
+    expect(helpers.getResponsiveImageAttributes({ src: "https://example.com/image.png", thumbnailSizes: [320] })).toBeNull();
+    expect(helpers.getResponsiveImageAttributes({ src: "/_thumbnails/image-320.webp", thumbnailSizes: [320] })).toBeNull();
+  });
+});

--- a/src/lib/responsive-images.test.ts
+++ b/src/lib/responsive-images.test.ts
@@ -37,3 +37,5 @@ describe("createResponsiveImageHelpers", () => {
     expect(helpers.getResponsiveImageAttributes({ src: "/_thumbnails/image-320.webp", thumbnailSizes: [320] })).toBeNull();
   });
 });
+
+

--- a/src/lib/responsive-images.ts
+++ b/src/lib/responsive-images.ts
@@ -86,3 +86,24 @@ export const isSupportedResponsiveImage = defaultResponsiveImageHelpers.isSuppor
 export const isGeneratedThumbnailPath = defaultResponsiveImageHelpers.isGeneratedThumbnailPath;
 export const getThumbnailPath = defaultResponsiveImageHelpers.getThumbnailPath;
 export const getResponsiveImageAttributes = defaultResponsiveImageHelpers.getResponsiveImageAttributes;
+
+export function getAssetUrl({
+  imageHost,
+  siteId,
+  s3SubDir,
+  filePath,
+  domain,
+}: {
+  imageHost?: string;
+  siteId: string;
+  s3SubDir: 'public' | 'content';
+  filePath: string;
+  domain?: string;
+}): string {
+  const cleanPath = filePath.replace(/^\//, '');
+  if (imageHost) {
+    return `${imageHost.replace(/\/+$/, '')}/${siteId}/${s3SubDir}/${cleanPath}`;
+  }
+  return `https://${domain || 'localhost'}/api/vault-public/${cleanPath}`;
+}
+

--- a/src/lib/responsive-images.ts
+++ b/src/lib/responsive-images.ts
@@ -1,0 +1,88 @@
+import path from 'path';
+import { DEFAULT_THUMBNAIL_SIZES, THUMBNAILS_DIR } from './constants';
+
+export const RESPONSIVE_IMAGE_SIZES = '(max-width: 768px) 100vw, 768px';
+
+const SUPPORTED_IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.avif', '.tif', '.tiff']);
+
+export type ResponsiveImageDeps = {
+  defaultThumbnailSizes: readonly number[];
+  generatedThumbnailDir: string;
+  responsiveImageSizes: string;
+  supportedImageExtensions: ReadonlySet<string>;
+  extname: (filePath: string) => string;
+  parsePosixPath: (filePath: string) => { dir: string; name: string };
+  encodeUri: (uri: string) => string;
+};
+
+export function createResponsiveImageHelpers(deps: ResponsiveImageDeps) {
+  function normalizeThumbnailSizes(sizes: readonly number[] | undefined): number[] {
+    const sourceSizes = sizes && sizes.length > 0 ? sizes : deps.defaultThumbnailSizes;
+    return [...new Set(sourceSizes.filter((size) => Number.isInteger(size) && size > 0))].sort((a, b) => a - b);
+  }
+
+  function isSupportedResponsiveImage(filePath: string): boolean {
+    return deps.supportedImageExtensions.has(deps.extname(filePath).toLowerCase());
+  }
+
+  function isGeneratedThumbnailPath(filePath: string): boolean {
+    return filePath.split('/').includes(deps.generatedThumbnailDir);
+  }
+
+  function getThumbnailPath({ imagePath, width }: { imagePath: string; width: number }): string {
+    const parsed = deps.parsePosixPath(imagePath.replace(/\\/g, '/'));
+    const dir = parsed.dir ? `${parsed.dir}/` : '';
+    return `${deps.generatedThumbnailDir}/${dir}${parsed.name}-${width}.webp`;
+  }
+
+  function getResponsiveImageAttributes({
+    src,
+    thumbnailSizes,
+  }: {
+    src: string;
+    thumbnailSizes: readonly number[];
+  }): { src: string; srcSet: string; sizes: string } | null {
+    if (src.startsWith('http://') || src.startsWith('https://') || src.startsWith('data:') || src.startsWith('#')) {
+      return null;
+    }
+
+    const cleanSrc = src.replace(/^\//, '');
+    if (!isSupportedResponsiveImage(cleanSrc) || isGeneratedThumbnailPath(cleanSrc)) {
+      return null;
+    }
+
+    const sizes = normalizeThumbnailSizes(thumbnailSizes);
+    if (sizes.length === 0) {
+      return null;
+    }
+
+    const srcSet = sizes
+      .map((size) => `${deps.encodeUri(`/${getThumbnailPath({ imagePath: cleanSrc, width: size })}`)} ${size}w`)
+      .join(', ');
+    return { src: deps.encodeUri(`/${cleanSrc}`), srcSet, sizes: deps.responsiveImageSizes };
+  }
+
+  return {
+    normalizeThumbnailSizes,
+    isSupportedResponsiveImage,
+    isGeneratedThumbnailPath,
+    getThumbnailPath,
+    getResponsiveImageAttributes,
+  };
+}
+
+const defaultResponsiveImageHelpers = createResponsiveImageHelpers({
+  defaultThumbnailSizes: DEFAULT_THUMBNAIL_SIZES,
+  generatedThumbnailDir: THUMBNAILS_DIR,
+  responsiveImageSizes: RESPONSIVE_IMAGE_SIZES,
+  supportedImageExtensions: SUPPORTED_IMAGE_EXTENSIONS,
+  extname: path.extname,
+  parsePosixPath: path.posix.parse,
+  encodeUri: encodeURI,
+});
+
+export const normalizeThumbnailSizes = defaultResponsiveImageHelpers.normalizeThumbnailSizes;
+export const isSupportedResponsiveImage = defaultResponsiveImageHelpers.isSupportedResponsiveImage;
+export const isGeneratedThumbnailPath = defaultResponsiveImageHelpers.isGeneratedThumbnailPath;
+export const getThumbnailPath = defaultResponsiveImageHelpers.getThumbnailPath;
+export const getResponsiveImageAttributes = defaultResponsiveImageHelpers.getResponsiveImageAttributes;

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getFileFromS3 } from "./s3";
-import { INDEX_SLUG, INDEX_JSON, ROOT_JSON } from "./constants";
+import { DEFAULT_THUMBNAIL_SIZES, INDEX_SLUG, INDEX_JSON, ROOT_JSON } from "./constants";
 import { createCache } from "./cache";
 
 export const PageMetadataSchema = z.object({
@@ -19,6 +19,7 @@ export const VaultDirectoryIndexSchema = z.object({
 export const VaultRootIndexSchema = VaultDirectoryIndexSchema.extend({
   directories: z.array(z.string()),
   publicFiles: z.array(z.string()),
+  thumbnailSizes: z.array(z.number().int().positive()).optional(),
 });
 
 export type PageMetadata = z.infer<typeof PageMetadataSchema>;
@@ -27,7 +28,7 @@ export type VaultRootIndex = z.infer<typeof VaultRootIndexSchema>;
 export type VaultIndex = VaultDirectoryIndex | VaultRootIndex;
 
 export type VaultContent =
-  | { type: "markdown"; content: string; matchedSlug: string; metadata: PageMetadata }
+  | { type: "markdown"; content: string; matchedSlug: string; metadata: PageMetadata; thumbnailSizes: readonly number[] }
   | { type: "collection"; pages: PageMetadata[]; requestedSlug: string }
   | { type: "asset"; filePath: string };
 
@@ -95,6 +96,7 @@ export async function resolveVaultRequest(config: VaultConfig, slugArray?: strin
   // 1. Fetch root index (The Master Map)
   const rootIndex = await fetchRootIndex(config);
   if (!rootIndex) return null;
+  const thumbnailSizes = rootIndex.thumbnailSizes || DEFAULT_THUMBNAIL_SIZES;
 
   // 2. Check for public asset match (only in root.json)
   if (segments.length > 0 && rootIndex.publicFiles.includes(requestedSlug)) {
@@ -107,7 +109,7 @@ export async function resolveVaultRequest(config: VaultConfig, slugArray?: strin
   const rootPageMatch = rootIndex.pages.find(p => p.slug === requestedSlug);
   if (rootPageMatch) {
     const markdown = await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${rootPageMatch.slug}.md`);
-    return { type: "markdown", content: markdown, matchedSlug: rootPageMatch.slug, metadata: rootPageMatch };
+    return { type: "markdown", content: markdown, matchedSlug: rootPageMatch.slug, metadata: rootPageMatch, thumbnailSizes };
   }
 
   // 3b. Is it a page in a nested directory? (Direct Jump)
@@ -120,7 +122,7 @@ export async function resolveVaultRequest(config: VaultConfig, slugArray?: strin
     if (nestedMatch) {
       // requestedSlug is the full path required for S3
       const markdown = await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${requestedSlug}.md`);
-      return { type: "markdown", content: markdown, matchedSlug: requestedSlug, metadata: nestedMatch };
+      return { type: "markdown", content: markdown, matchedSlug: requestedSlug, metadata: nestedMatch, thumbnailSizes };
     }
   }
 
@@ -136,7 +138,7 @@ export async function resolveVaultRequest(config: VaultConfig, slugArray?: strin
       if (indexMatch) {
         const fullPath = targetDir ? `${targetDir}/${INDEX_SLUG}` : INDEX_SLUG;
         const markdown = await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${fullPath}.md`);
-        return { type: "markdown", content: markdown, matchedSlug: fullPath, metadata: indexMatch };
+        return { type: "markdown", content: markdown, matchedSlug: fullPath, metadata: indexMatch, thumbnailSizes };
       }
 
       // Priority 2: Return collection view


### PR DESCRIPTION
## Overview
This PR introduces robust support for responsive image thumbnails, WordPress REST API integration/publishing, and improved conversion of Obsidian wikilink image patterns to HTML/markdown. It also refactors the codebase to use Dependency Injection (DI) for image helpers, making them more modular and testable.

## Key Changes
- **Responsive Image Thumbnails (DI Pattern):**
  - Created modular helpers ([src/lib/responsive-images.ts](file:///Users/shiu/Documents/GitHub/notopress/src/lib/responsive-images.ts)) with Dependency Injection to manage thumbnail sizes, extensions, and paths.
  - Added comprehensive unit tests for all DI modules.
- **WordPress REST API Publishing Integration:**
  - Added REST API logic in [scripts/lib/wordpress.ts](file:///Users/shiu/Documents/GitHub/notopress/scripts/lib/wordpress.ts) to fetch/check existing posts and dynamically create or update posts.
  - Automatically translates local image assets inside WordPress posts to CDN/S3 hosted URLs.
  - Applied standard styling (`style="max-width: 100%;"`) to WordPress post images and removed unused size classes.
- **Obsidian Wikilink Conversion:**
  - Added support for detecting, parsing, and resolving wikilinks containing image extensions.
  - Wrapped standalone markdown images in `<figure>` and `<figcaption>` tags for clean WordPress/web rendering.
  - Wrapped image paths in angle brackets to fully support filenames with spaces.
- **Modular Utilities:**
  - Split up monolithic CLI tasks into dedicated testable scripts/modules ([scripts/lib/files.ts](file:///Users/shiu/Documents/GitHub/notopress/scripts/lib/files.ts), [scripts/lib/indices.ts](file:///Users/shiu/Documents/GitHub/notopress/scripts/lib/indices.ts), [scripts/lib/sitemaps.ts](file:///Users/shiu/Documents/GitHub/notopress/scripts/lib/sitemaps.ts), [scripts/lib/thumbnails.ts](file:///Users/shiu/Documents/GitHub/notopress/scripts/lib/thumbnails.ts)).
