### PR TITLE
feat: add support for pulling WordPress posts to local Markdown

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -12,7 +12,7 @@ import { normalizeThumbnailSizes } from '../src/lib/responsive-images';
 import { exists } from './lib/files';
 import { generateIndices } from './lib/indices';
 import { generateSitemaps } from './lib/sitemaps';
-import { pushToWordPress } from './lib/wordpress';
+import { pushToWordPress, pullFromWordPress } from './lib/wordpress';
 
 type CommandResult = {
   status: number | null;
@@ -450,6 +450,25 @@ async function main() {
 
     if (mode === 'configure') {
       await configureLocalEnvironment({ site, registry });
+      return;
+    }
+
+    const pullSlugOrId = getFlagValue({ flag: '--pull' });
+    if (pullSlugOrId) {
+      const thumbnailSizes = normalizeThumbnailSizes(site.thumbnailSizes || registry.thumbnailSizes);
+      const { allIndices } = await generateIndices({
+        vaultPath: site.vaultPath,
+        thumbnailSizes,
+        dryRun: true,
+      });
+
+      await pullFromWordPress({
+        site,
+        registry,
+        allIndices,
+        slugOrId: pullSlugOrId,
+        dryRun: isDryRun,
+      });
       return;
     }
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -311,7 +311,7 @@ describe('WordPress Deployment Library', () => {
   describe('restoreLocalImagePath', () => {
     it('should return simple relative paths unchanged', () => {
       const result = restoreLocalImagePath('/images/photo.png', mockSite, mockRegistry);
-      expect(result).toBe('/images/photo.png');
+      expect(result).toBe('images/photo.png');
     });
 
     it('should resolve thumbnail CDN url to local relative path with correct original extension from disk', () => {
@@ -364,7 +364,7 @@ describe('WordPress Deployment Library', () => {
     it('should parse links and simple images', () => {
       const html = '<p>Link to <a href="https://google.com">Google</a> and <img src="/images/pic.png" alt="Pic" /></p>';
       const md = htmlToMarkdown(html, mockSite, mockRegistry);
-      expect(md).toBe('Link to [Google](https://google.com) and ![Pic](/images/pic.png)');
+      expect(md).toBe('Link to [Google](https://google.com) and ![Pic](images/pic.png)');
     });
 
     it('should parse code blocks and inline code', () => {
@@ -394,7 +394,25 @@ describe('WordPress Deployment Library', () => {
     it('should parse figures and figcaptions', () => {
       const html = '<figure class="wp-block-image"><img src="/images/fig.png" alt="Alt text" /><figcaption>Caption text</figcaption></figure>';
       const md = htmlToMarkdown(html, mockSite, mockRegistry);
-      expect(md).toBe('![Alt text](/images/fig.png)');
+      expect(md).toBe('![Alt text](images/fig.png)\n*Caption text*');
+    });
+
+    it('should parse figures with link inside figcaption', () => {
+      const html = '<figure><img src="/images/fig.png" alt="Alt" /><figcaption>Source: <a href="http://google.com">Google</a></figcaption></figure>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('![Alt](images/fig.png)\n*Source: [Google](http://google.com)*');
+    });
+
+    it('should parse HTML tables and captions into markdown tables', () => {
+      const html = '<table><caption>List of codes</caption><thead><tr><th>Region</th><th>Code</th></tr></thead><tbody><tr><td>USA</td><td>+1</td></tr></tbody></table>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('*List of codes*\n\n| Region | Code |\n| --- | --- |\n| USA | +1 |');
+    });
+
+    it('should strip comments and scripts from HTML content', () => {
+      const html = '<!-- wp:paragraph --><p>Hello</p><script>console.log(123);</script>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('Hello');
     });
   });
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -349,10 +349,10 @@ describe('WordPress Deployment Library', () => {
   });
 
   describe('htmlToMarkdown', () => {
-    it('should parse basic html elements to markdown', () => {
-      const html = '<p>Hello <strong>world</strong> and <em>everyone</em>!</p>';
+    it('should parse basic html elements to markdown and decode HTML entities', () => {
+      const html = '<p>Hello <strong>world</strong> and <em>everyone</em>! &#8211; &ldquo;Quotes&rdquo; &amp; &hellip;</p>';
       const md = htmlToMarkdown(html, mockSite, mockRegistry);
-      expect(md).toBe('Hello **world** and *everyone*!');
+      expect(md).toBe('Hello **world** and *everyone*! – “Quotes” & …');
     });
 
     it('should parse headings', () => {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -328,7 +328,7 @@ describe('WordPress Deployment Library', () => {
         mockSite,
         mockRegistry
       );
-      expect(result).toBe('/images/avatar.jpg');
+      expect(result).toBe('images/avatar.jpg');
     });
 
     it('should resolve direct non-thumbnail image url and find original path on disk', () => {
@@ -344,7 +344,7 @@ describe('WordPress Deployment Library', () => {
         mockSite,
         mockRegistry
       );
-      expect(result).toBe('/docs/screenshot.png');
+      expect(result).toBe('docs/screenshot.png');
     });
   });
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { replaceLocalImagesWithThumbnails, pushToWordPress } from './wordpress';
+import { replaceLocalImagesWithThumbnails, pushToWordPress, restoreLocalImagePath, htmlToMarkdown, pullFromWordPress } from './wordpress';
 import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
 
@@ -8,14 +8,22 @@ vi.mock('./files', () => ({
   getAssetSubDir: vi.fn(),
 }));
 
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
   readdir: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
 }));
 
 // Access mocked functions
 import { getAssetSubDir } from './files';
-import { readFile, readdir } from 'fs/promises';
+import { readFile, readdir, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+
 
 describe('WordPress Deployment Library', () => {
   const mockSite: Site = {
@@ -299,4 +307,204 @@ describe('WordPress Deployment Library', () => {
       expect(body.content).toContain('<h1>Real Title</h1>');
     });
   });
+
+  describe('restoreLocalImagePath', () => {
+    it('should return simple relative paths unchanged', () => {
+      const result = restoreLocalImagePath('/images/photo.png', mockSite, mockRegistry);
+      expect(result).toBe('/images/photo.png');
+    });
+
+    it('should resolve thumbnail CDN url to local relative path with correct original extension from disk', () => {
+      // Mock existsSync to simulate file existing on disk
+      vi.mocked(existsSync).mockImplementation((p) => {
+        if (typeof p === 'string' && p.endsWith('/mock/vault/public/images/avatar.jpg')) {
+          return true;
+        }
+        return false;
+      });
+
+      const result = restoreLocalImagePath(
+        'https://cdn.testsite.com/test-blog/public/_thumbnails/images/avatar-640.webp',
+        mockSite,
+        mockRegistry
+      );
+      expect(result).toBe('/images/avatar.jpg');
+    });
+
+    it('should resolve direct non-thumbnail image url and find original path on disk', () => {
+      vi.mocked(existsSync).mockImplementation((p) => {
+        if (typeof p === 'string' && p.endsWith('/mock/vault/content/docs/screenshot.png')) {
+          return true;
+        }
+        return false;
+      });
+
+      const result = restoreLocalImagePath(
+        '/api/vault-public/docs/screenshot.webp',
+        mockSite,
+        mockRegistry
+      );
+      expect(result).toBe('/docs/screenshot.png');
+    });
+  });
+
+  describe('htmlToMarkdown', () => {
+    it('should parse basic html elements to markdown', () => {
+      const html = '<p>Hello <strong>world</strong> and <em>everyone</em>!</p>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('Hello **world** and *everyone*!');
+    });
+
+    it('should parse headings', () => {
+      const html = '<h1>Title 1</h1><h2>Title 2</h2><h3>Title 3</h3>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('# Title 1\n\n## Title 2\n\n### Title 3');
+    });
+
+    it('should parse links and simple images', () => {
+      const html = '<p>Link to <a href="https://google.com">Google</a> and <img src="/images/pic.png" alt="Pic" /></p>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('Link to [Google](https://google.com) and ![Pic](/images/pic.png)');
+    });
+
+    it('should parse code blocks and inline code', () => {
+      const html = '<p>Use <code>const x = 5</code></p><pre class="wp-block-code"><code class="language-js">const y = 6;\nconsole.log(y);</code></pre>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('Use `const x = 5`\n\n```js\nconst y = 6;\nconsole.log(y);\n```');
+    });
+
+    it('should parse blockquotes', () => {
+      const html = '<blockquote><p>Quote text here.</p></blockquote>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('> Quote text here.');
+    });
+
+    it('should parse nested unordered lists with correct indent', () => {
+      const html = '<ul><li>Item 1</li><li>Item 2<ul><li>Subitem 1</li><li>Subitem 2</li></ul></li></ul>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('- Item 1\n- Item 2\n  - Subitem 1\n  - Subitem 2');
+    });
+
+    it('should parse nested ordered lists with correct numbers', () => {
+      const html = '<ol><li>One</li><li>Two<ol><li>Sub One</li><li>Sub Two</li></ol></li></ol>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('1. One\n2. Two\n  1. Sub One\n  2. Sub Two');
+    });
+
+    it('should parse figures and figcaptions', () => {
+      const html = '<figure class="wp-block-image"><img src="/images/fig.png" alt="Alt text" /><figcaption>Caption text</figcaption></figure>';
+      const md = htmlToMarkdown(html, mockSite, mockRegistry);
+      expect(md).toBe('![Alt text](/images/fig.png)');
+    });
+  });
+
+  describe('pullFromWordPress', () => {
+    const mockIndices = new Map<string, VaultDirectoryIndex>([
+      [
+        '',
+        {
+          version: 1,
+          pages: [
+            {
+              title: 'Post One',
+              slug: 'post-one',
+              date: '2026-06-16T12:00:00.000Z',
+              excerpt: 'An excerpt.',
+            },
+          ],
+        },
+      ],
+    ]);
+
+    it('should pull a post by slug from wordpress, convert content, and write markdown file to the correct local path', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts?slug=post-one') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [
+              {
+                id: 123,
+                date: '2026-06-30T10:00:00',
+                modified: '2026-06-30T11:00:00',
+                slug: 'post-one',
+                title: { rendered: 'Post One Title' },
+                content: { rendered: '<p>WordPress body text.</p>' },
+                status: 'publish',
+              },
+            ],
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      await pullFromWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        slugOrId: 'post-one',
+        dryRun: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts?slug=post-one'),
+        expect.objectContaining({ method: 'GET' })
+      );
+
+      // Verify that writeFile is called with the compiled markdown and correct path
+      expect(mkdir).toHaveBeenCalledWith('/mock/vault/content', { recursive: true });
+      expect(writeFile).toHaveBeenCalledWith(
+        '/mock/vault/content/post-one.md',
+        expect.stringContaining('title: "Post One Title"'),
+        'utf-8'
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        '/mock/vault/content/post-one.md',
+        expect.stringContaining('# Post One Title\n\nWordPress body text.'),
+        'utf-8'
+      );
+    });
+
+    it('should fallback to target ID if slug fails', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts?slug=123') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/posts/123') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => ({
+              id: 123,
+              date: '2026-06-30T10:00:00',
+              modified: '2026-06-30T11:00:00',
+              slug: 'pulled-post-slug',
+              title: { rendered: 'Pulled Title' },
+              content: { rendered: '<p>Fetched by ID.</p>' },
+              status: 'publish',
+            }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      await pullFromWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        slugOrId: '123',
+        dryRun: false,
+      });
+
+      expect(writeFile).toHaveBeenCalledWith(
+        '/mock/vault/content/pulled-post-slug.md',
+        expect.stringContaining('# Pulled Title\n\nFetched by ID.'),
+        'utf-8'
+      );
+    });
+  });
 });
+

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -447,10 +447,9 @@ export function resolveAndCollectImagePath(
 
   // Check if the file already exists locally
   const dir = path.dirname(tempPath);
-  const candidateFolders = ['attachments', 'images', dir !== '.' ? dir : '', ''];
-  if (slug) {
-    candidateFolders.unshift(slug);
-  }
+  const candidateFolders = slug 
+    ? [slug] 
+    : ['attachments', 'images', dir !== '.' ? dir : '', ''];
   const extensions = [ext, '.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif'];
 
   for (const folder of candidateFolders) {

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -1,4 +1,5 @@
-import { readFile } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
 import { getAssetSubDir } from './files';
@@ -364,3 +365,401 @@ export async function pushToWordPress({
     }
   }
 }
+
+interface WpPost {
+  id: number;
+  date: string;
+  modified: string;
+  slug: string;
+  title: {
+    rendered: string;
+  };
+  content: {
+    rendered: string;
+  };
+  status: string;
+}
+
+export function restoreLocalImagePath(src: string, site: Site, registry: Registry): string {
+  // If it's a relative path already, just return it
+  if (src.startsWith('/') && !src.startsWith('//') && !src.includes('/api/vault-public/') && !src.includes('_thumbnails/')) {
+    return src;
+  }
+
+  let tempPath = src;
+
+  // Remove protocol and host if present
+  if (tempPath.startsWith('http://') || tempPath.startsWith('https://')) {
+    try {
+      const urlObj = new URL(tempPath);
+      tempPath = urlObj.pathname + urlObj.search + urlObj.hash;
+    } catch {
+      // ignore
+    }
+  }
+
+  // Remove leading slash
+  tempPath = tempPath.replace(/^\//, '');
+
+  // If it goes through api/vault-public
+  if (tempPath.startsWith('api/vault-public/')) {
+    tempPath = tempPath.substring('api/vault-public/'.length);
+  }
+
+  // If it has siteId prefix (e.g. test-blog/content/...)
+  const siteIdPrefix = `${site.siteId}/`;
+  if (tempPath.startsWith(siteIdPrefix)) {
+    tempPath = tempPath.substring(siteIdPrefix.length);
+    if (tempPath.startsWith('content/')) {
+      tempPath = tempPath.substring('content/'.length);
+    } else if (tempPath.startsWith('public/')) {
+      tempPath = tempPath.substring('public/'.length);
+    }
+  }
+
+  // Now, check if it contains _thumbnails
+  const thumbIndex = tempPath.indexOf('_thumbnails/');
+  if (thumbIndex !== -1) {
+    tempPath = tempPath.substring(thumbIndex + '_thumbnails/'.length);
+    // Strip width suffix like -1200.webp
+    const match = tempPath.match(/(.+)-\d+\.webp$/);
+    if (match) {
+      tempPath = match[1];
+    } else {
+      tempPath = tempPath.replace(/\.[^/.]+$/, "");
+    }
+
+    // Now look on disk for the original extension
+    const extensions = ['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif', '.tiff', '.tif'];
+    for (const ext of extensions) {
+      const publicPath = path.join(site.vaultPath, 'public', `${tempPath}${ext}`);
+      const contentPath = path.join(site.vaultPath, 'content', `${tempPath}${ext}`);
+      if (existsSync(publicPath)) {
+        return `/${tempPath}${ext}`;
+      }
+      if (existsSync(contentPath)) {
+        return `/${tempPath}${ext}`;
+      }
+    }
+    // Fallback if not found on disk
+    return `/${tempPath}.webp`;
+  }
+
+  // Even if it didn't contain _thumbnails, let's check if the file with its extension
+  // or other common extensions exists on disk
+  const basePathWithoutExt = tempPath.replace(/\.[^/.]+$/, "");
+  const extensions = ['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif', '.tiff', '.tif'];
+  for (const ext of extensions) {
+    if (existsSync(path.join(site.vaultPath, 'public', `${basePathWithoutExt}${ext}`))) {
+      return `/${basePathWithoutExt}${ext}`;
+    }
+    if (existsSync(path.join(site.vaultPath, 'content', `${basePathWithoutExt}${ext}`))) {
+      return `/${basePathWithoutExt}${ext}`;
+    }
+  }
+
+  return `/${tempPath}`;
+}
+
+export function htmlToMarkdown(html: string, site: Site, registry: Registry): string {
+  // Tokenize the HTML
+  const tagRegex = /(<\/?[a-zA-Z0-9:-]+(?:\s+[a-zA-Z0-9:-]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]+))?)*\s*\/?>)/g;
+  const parts = html.split(tagRegex);
+  
+  interface Node {
+    type: string;
+    attributes: Record<string, string>;
+    children: Node[];
+    text?: string;
+  }
+
+  const root: Node = { type: 'root', attributes: {}, children: [] };
+  const stack: Node[] = [root];
+
+  for (const part of parts) {
+    if (!part) continue;
+    if (part.startsWith('<') && part.endsWith('>')) {
+      const isClosing = part.startsWith('</');
+      const tagContent = part.replace(/^<\/?/, '').replace(/\/?>$/, '').trim();
+      const tagName = tagContent.split(/\s+/)[0].toLowerCase();
+      
+      const isSelfClosing = part.endsWith('/>') || /^(?:img|br|hr|input|meta|link)$/i.test(tagName);
+      
+      if (isClosing) {
+        const openIdx = [...stack].reverse().findIndex(n => n.type === tagName);
+        if (openIdx !== -1) {
+          const actualIdx = stack.length - 1 - openIdx;
+          stack.splice(actualIdx);
+        }
+      } else {
+        const attributes: Record<string, string> = {};
+        const attrRegex = /([a-zA-Z0-9:-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g;
+        let match;
+        const attrString = tagContent.substring(tagName.length);
+        while ((match = attrRegex.exec(attrString)) !== null) {
+          const key = match[1].toLowerCase();
+          const value = match[2] ?? match[3] ?? match[4] ?? '';
+          attributes[key] = value;
+        }
+
+        const node: Node = { type: tagName, attributes, children: [] };
+        stack[stack.length - 1].children.push(node);
+
+        if (!isSelfClosing) {
+          stack.push(node);
+        }
+      }
+    } else {
+      const text = decodeHtmlEntities(part);
+      if (text) {
+        stack[stack.length - 1].children.push({ type: 'text', attributes: {}, children: [], text });
+      }
+    }
+  }
+
+  function decodeHtmlEntities(str: string): string {
+    return str
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#039;/g, "'")
+      .replace(/&#39;/g, "'")
+      .replace(/&ldquo;/g, '“')
+      .replace(/&rdquo;/g, '”')
+      .replace(/&lsquo;/g, '‘')
+      .replace(/&rsquo;/g, '’')
+      .replace(/&ndash;/g, '–')
+      .replace(/&mdash;/g, '—')
+      .replace(/&nbsp;/g, ' ');
+  }
+
+  function render(node: Node, listDepth = 0): string {
+    if (node.type === 'text') {
+      return node.text || '';
+    }
+
+    const childrenContent = node.children.map(c => render(c, listDepth)).join('');
+
+    switch (node.type) {
+      case 'root':
+        return childrenContent.trim();
+      case 'p':
+        return `\n\n${childrenContent.trim()}\n\n`;
+      case 'h1':
+        return `\n\n# ${childrenContent.trim()}\n\n`;
+      case 'h2':
+        return `\n\n## ${childrenContent.trim()}\n\n`;
+      case 'h3':
+        return `\n\n### ${childrenContent.trim()}\n\n`;
+      case 'h4':
+        return `\n\n#### ${childrenContent.trim()}\n\n`;
+      case 'h5':
+        return `\n\n##### ${childrenContent.trim()}\n\n`;
+      case 'h6':
+        return `\n\n###### ${childrenContent.trim()}\n\n`;
+      case 'strong':
+      case 'b':
+        return `**${childrenContent}**`;
+      case 'em':
+      case 'i':
+        return `*${childrenContent}*`;
+      case 'code':
+        return `\`${childrenContent}\``;
+      case 'pre': {
+        const codeNode = node.children.find(c => c.type === 'code');
+        const codeText = codeNode ? codeNode.children.map(c => render(c, listDepth)).join('') : childrenContent;
+        const className = codeNode?.attributes['class'] || node.attributes['class'] || '';
+        const langMatch = className.match(/language-([a-zA-Z0-9+-]+)/);
+        const lang = langMatch ? langMatch[1] : '';
+        return `\n\n\`\`\`${lang}\n${codeText.trim()}\n\`\`\`\n\n`;
+      }
+      case 'blockquote':
+        return `\n\n> ${childrenContent.trim().replace(/\n/g, '\n> ')}\n\n`;
+      case 'ul': {
+        const content = node.children.map(c => render(c, listDepth + 1)).join('');
+        if (listDepth > 0) {
+          return `\n${content.trimEnd()}`;
+        }
+        return `\n\n${content.trim()}\n\n`;
+      }
+      case 'ol': {
+        let index = 1;
+        const content = node.children.map(c => {
+          if (c.type === 'li') {
+            return render(c, listDepth + 1).replace(/^(\s*)-\s+/, `$1${index++}. `);
+          }
+          return render(c, listDepth + 1);
+        }).join('');
+        if (listDepth > 0) {
+          return `\n${content.trimEnd()}`;
+        }
+        return `\n\n${content.trim()}\n\n`;
+      }
+      case 'li': {
+        const indent = '  '.repeat(Math.max(0, listDepth - 1));
+        return `${indent}- ${childrenContent.trim()}\n`;
+      }
+      case 'a':
+        const href = node.attributes['href'] || '';
+        return `[${childrenContent}](${href})`;
+      case 'img': {
+        const src = node.attributes['src'] || '';
+        const alt = node.attributes['alt'] || '';
+        const localSrc = restoreLocalImagePath(src, site, registry);
+        return `![${alt}](${localSrc})`;
+      }
+      case 'figure': {
+        const img = findNodeByType(node, 'img');
+        if (!img) return childrenContent;
+        const src = img.attributes['src'] || '';
+        const alt = img.attributes['alt'] || '';
+        const figcaption = findNodeByType(node, 'figcaption');
+        const captionText = figcaption ? getPlainText(figcaption).trim() : '';
+        const finalAlt = alt || captionText;
+        const localSrc = restoreLocalImagePath(src, site, registry);
+        return `\n\n![${finalAlt}](${localSrc})\n\n`;
+      }
+      case 'figcaption':
+        return '';
+      case 'br':
+        return '\n';
+      case 'hr':
+        return '\n\n---\n\n';
+      default:
+        return childrenContent;
+    }
+  }
+
+  function findNodeByType(node: Node, type: string): Node | null {
+    if (node.type === type) return node;
+    for (const child of node.children) {
+      const found = findNodeByType(child, type);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  function getPlainText(node: Node): string {
+    if (node.type === 'text') return node.text || '';
+    return node.children.map(getPlainText).join('');
+  }
+
+  const result = render(root);
+  return result
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+interface PullFromWordPressArgs {
+  site: Site;
+  registry: Registry;
+  allIndices: Map<string, VaultDirectoryIndex>;
+  slugOrId: string;
+  dryRun: boolean;
+}
+
+export async function pullFromWordPress({
+  site,
+  registry,
+  allIndices,
+  slugOrId,
+  dryRun,
+}: PullFromWordPressArgs) {
+  const credentials = site.wordpress;
+  if (!credentials) {
+    throw new Error(`⨯ WordPress credentials are not configured for site [${site.siteId}].`);
+  }
+
+  const endpoint = credentials.endpoint || `https://${site.domain}/wp-json`;
+  console.log(`\n📥 Preparing WordPress Pull...`);
+  console.log(`- Target Endpoint: ${endpoint}`);
+  console.log(`- Authenticated As: ${credentials.username}`);
+  console.log(`- Target Post Slug/ID: ${slugOrId}`);
+  console.log(dryRun ? `- Mode: DRY RUN (No changes will be written)\n` : `- Mode: Live Pull\n`);
+
+  let wpPost: WpPost | null = null;
+
+  // 1. Try to fetch by slug first (WordPress uses hyphens instead of slashes)
+  const wpSlug = slugOrId.replace(/\//g, '-');
+  try {
+    const posts = (await wpFetch({
+      endpoint,
+      credentials,
+      path: `/wp/v2/posts?slug=${encodeURIComponent(wpSlug)}&status=any`,
+    })) as WpPost[];
+    
+    if (posts && posts.length > 0) {
+      wpPost = posts[0];
+    }
+  } catch (err) {
+    console.log(`  (Slug lookup for "${wpSlug}" returned no results or failed, checking ID...)`);
+  }
+
+  // 2. Try to fetch by ID if slug lookup didn't yield a post
+  if (!wpPost && /^\d+$/.test(slugOrId)) {
+    try {
+      wpPost = (await wpFetch({
+        endpoint,
+        credentials,
+        path: `/wp/v2/posts/${slugOrId}`,
+      })) as WpPost;
+    } catch (err) {
+      // Failed to find by ID
+    }
+  }
+
+  if (!wpPost) {
+    throw new Error(`⨯ Could not find any post in WordPress matching slug or ID: "${slugOrId}"`);
+  }
+
+  console.log(`✅ Found post: "${wpPost.title.rendered}" (ID: wpPost ID: ${wpPost.id}, Slug: ${wpPost.slug})`);
+
+  // Convert HTML to Markdown
+  const markdownBody = htmlToMarkdown(wpPost.content.rendered, site, registry);
+
+  // Prepend frontmatter and title heading
+  const frontmatter = [
+    `---`,
+    `title: "${wpPost.title.rendered.replace(/"/g, '\\"')}"`,
+    `date: "${new Date(wpPost.date).toISOString()}"`,
+    `updated: "${new Date(wpPost.modified).toISOString()}"`,
+    `---`,
+    ``,
+    `# ${wpPost.title.rendered}`,
+    ``,
+    markdownBody,
+    ``,
+  ].join('\n');
+
+  // Find local path from indices
+  let targetLocalPath = '';
+  for (const [dirKey, dirIndex] of allIndices.entries()) {
+    for (const page of dirIndex.pages) {
+      const fullSlug = dirKey ? `${dirKey}/${page.slug}` : page.slug;
+      if (fullSlug.replace(/\//g, '-') === wpPost.slug) {
+        targetLocalPath = path.join(site.vaultPath, 'content', dirKey, `${page.slug}.md`);
+        break;
+      }
+    }
+    if (targetLocalPath) break;
+  }
+
+  if (!targetLocalPath) {
+    targetLocalPath = path.join(site.vaultPath, 'content', `${wpPost.slug}.md`);
+  }
+
+  if (dryRun) {
+    console.log(`  [DRY RUN] Would write Markdown post for "${wpPost.title.rendered}" to:`);
+    console.log(`  📂 ${targetLocalPath}`);
+    console.log(`\n--- PREVIEW START ---`);
+    console.log(frontmatter);
+    console.log(`--- PREVIEW END ---`);
+  } else {
+    // Ensure parent directory exists
+    await mkdir(path.dirname(targetLocalPath), { recursive: true });
+    await writeFile(targetLocalPath, frontmatter, 'utf-8');
+    console.log(`  💾 Successfully pulled and saved post to: ${targetLocalPath}`);
+  }
+}
+

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -369,7 +369,9 @@ export async function pushToWordPress({
 interface WpPost {
   id: number;
   date: string;
+  date_gmt?: string;
   modified: string;
+  modified_gmt?: string;
   slug: string;
   title: {
     rendered: string;
@@ -380,6 +382,38 @@ interface WpPost {
   status: string;
 }
 
+export function decodeHtmlEntities(str: string): string {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&ldquo;/g, '“')
+    .replace(/&rdquo;/g, '”')
+    .replace(/&lsquo;/g, '‘')
+    .replace(/&rsquo;/g, '’')
+    .replace(/&ndash;/g, '–')
+    .replace(/&mdash;/g, '—')
+    .replace(/&hellip;/g, '…')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, dec) => {
+      try {
+        return String.fromCodePoint(parseInt(dec, 10));
+      } catch {
+        return _;
+      }
+    })
+    .replace(/&#x([a-fA-F0-9]+);/g, (_, hex) => {
+      try {
+        return String.fromCodePoint(parseInt(hex, 16));
+      } catch {
+        return _;
+      }
+    });
+}
+
 export function resolveAndCollectImagePath(
   src: string,
   site: Site,
@@ -387,9 +421,9 @@ export function resolveAndCollectImagePath(
   slug = '',
   collectedImages?: { remoteUrl: string; tryHighResUrl: string; localPath: string }[]
 ): string {
-  // If it's a relative path already, just return it
+  // If it's a relative path already, just return it without leading slash
   if (src.startsWith('/') && !src.startsWith('//') && !src.includes('/api/vault-public/') && !src.includes('_thumbnails/')) {
-    return src;
+    return src.replace(/^\//, '');
   }
 
   let tempPath = src;
@@ -410,7 +444,7 @@ export function resolveAndCollectImagePath(
       if (!isInternal) {
         isExternal = true;
       }
-      tempPath = urlObj.pathname + urlObj.search + urlObj.hash;
+      tempPath = urlObj.pathname;
     } catch {
       isExternal = true;
     }
@@ -418,6 +452,16 @@ export function resolveAndCollectImagePath(
 
   // Remove leading slash
   tempPath = tempPath.replace(/^\//, '');
+
+  // Strip query parameters and hash from tempPath
+  const questionMarkIndex = tempPath.indexOf('?');
+  if (questionMarkIndex !== -1) {
+    tempPath = tempPath.substring(0, questionMarkIndex);
+  }
+  const hashIndex = tempPath.indexOf('#');
+  if (hashIndex !== -1) {
+    tempPath = tempPath.substring(0, hashIndex);
+  }
 
   // If it goes through api/vault-public
   if (tempPath.startsWith('api/vault-public/')) {
@@ -518,9 +562,14 @@ export function htmlToMarkdown(
   slug = '',
   collectedImages?: { remoteUrl: string; tryHighResUrl: string; localPath: string }[]
 ): string {
+  // Strip script tags and HTML comments
+  const cleanHtml = html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+
   // Tokenize the HTML
   const tagRegex = /(<\/?[a-zA-Z0-9:-]+(?:\s+[a-zA-Z0-9:-]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]+))?)*\s*\/?>)/g;
-  const parts = html.split(tagRegex);
+  const parts = cleanHtml.split(tagRegex);
   
   interface Node {
     type: string;
@@ -573,38 +622,6 @@ export function htmlToMarkdown(
     }
   }
 
-  function decodeHtmlEntities(str: string): string {
-    return str
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#039;/g, "'")
-      .replace(/&#39;/g, "'")
-      .replace(/&ldquo;/g, '“')
-      .replace(/&rdquo;/g, '”')
-      .replace(/&lsquo;/g, '‘')
-      .replace(/&rsquo;/g, '’')
-      .replace(/&ndash;/g, '–')
-      .replace(/&mdash;/g, '—')
-      .replace(/&hellip;/g, '…')
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&#(\d+);/g, (_, dec) => {
-        try {
-          return String.fromCodePoint(parseInt(dec, 10));
-        } catch {
-          return _;
-        }
-      })
-      .replace(/&#x([a-fA-F0-9]+);/g, (_, hex) => {
-        try {
-          return String.fromCodePoint(parseInt(hex, 16));
-        } catch {
-          return _;
-        }
-      });
-  }
-
   function render(node: Node, listDepth = 0): string {
     if (node.type === 'text') {
       return node.text || '';
@@ -648,7 +665,8 @@ export function htmlToMarkdown(
       case 'blockquote':
         return `\n\n> ${childrenContent.trim().replace(/\n/g, '\n> ')}\n\n`;
       case 'ul': {
-        const content = node.children.map(c => render(c, listDepth + 1)).join('');
+        const childrenToRender = node.children.filter(c => c.type !== 'text' || (c.text && c.text.trim() !== ''));
+        const content = childrenToRender.map(c => render(c, listDepth + 1)).join('');
         if (listDepth > 0) {
           return `\n${content.trimEnd()}`;
         }
@@ -656,7 +674,8 @@ export function htmlToMarkdown(
       }
       case 'ol': {
         let index = 1;
-        const content = node.children.map(c => {
+        const childrenToRender = node.children.filter(c => c.type !== 'text' || (c.text && c.text.trim() !== ''));
+        const content = childrenToRender.map(c => {
           if (c.type === 'li') {
             return render(c, listDepth + 1).replace(/^(\s*)-\s+/, `$1${index++}. `);
           }
@@ -685,14 +704,38 @@ export function htmlToMarkdown(
         if (!img) return childrenContent;
         const src = img.attributes['src'] || '';
         const alt = img.attributes['alt'] || '';
+        
         const figcaption = findNodeByType(node, 'figcaption');
-        const captionText = figcaption ? getPlainText(figcaption).trim() : '';
-        const finalAlt = alt || captionText;
+        let captionMarkdown = '';
+        if (figcaption) {
+          captionMarkdown = `\n*${render(figcaption, listDepth).trim()}*\n`;
+        }
+
         const localSrc = resolveAndCollectImagePath(src, site, registry, slug, collectedImages);
-        return `\n\n![${finalAlt}](${localSrc})\n\n`;
+        return `\n\n![${alt}](${localSrc})${captionMarkdown}\n\n`;
       }
+      case 'table':
+        return `\n\n${childrenContent.trim()}\n\n`;
+      case 'caption':
+        return `*${childrenContent.trim()}*\n\n`;
+      case 'thead':
+      case 'tbody':
+        return childrenContent;
+      case 'tr': {
+        const cells = node.children.filter(c => c.type === 'th' || c.type === 'td');
+        const rowText = `| ${cells.map(c => render(c, listDepth)).join(' | ')} |\n`;
+        const isHeader = cells.some(c => c.type === 'th');
+        if (isHeader) {
+          const sepRow = `| ${cells.map(() => '---').join(' | ')} |\n`;
+          return `${rowText}${sepRow}`;
+        }
+        return rowText;
+      }
+      case 'th':
+      case 'td':
+        return childrenContent.trim().replace(/\n/g, ' ');
       case 'figcaption':
-        return '';
+        return childrenContent;
       case 'br':
         return '\n';
       case 'hr':
@@ -764,7 +807,11 @@ export async function pullFromWordPress({
       wpPost = posts[0];
     }
   } catch (err) {
-    console.log(`  (Slug lookup for "${wpSlug}" returned no results or failed, checking ID...)`);
+    const errMsg = err instanceof Error ? err.message : String(err);
+    if (errMsg.includes('401') || errMsg.includes('403')) {
+      throw new Error(`⨯ WordPress authentication failed: ${errMsg}`);
+    }
+    console.log(`  (Slug lookup for "${wpSlug}" failed: ${errMsg}. Checking ID...)`);
   }
 
   // 2. Try to fetch by ID if slug lookup didn't yield a post
@@ -776,6 +823,10 @@ export async function pullFromWordPress({
         path: `/wp/v2/posts/${slugOrId}`,
       })) as WpPost;
     } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (errMsg.includes('401') || errMsg.includes('403')) {
+        throw new Error(`⨯ WordPress authentication failed: ${errMsg}`);
+      }
       // Failed to find by ID
     }
   }
@@ -790,15 +841,28 @@ export async function pullFromWordPress({
   const collectedImages: { remoteUrl: string; tryHighResUrl: string; localPath: string }[] = [];
   const markdownBody = htmlToMarkdown(wpPost.content.rendered, site, registry, wpPost.slug, collectedImages);
 
+  // Parse Date GMT to prevent timezone shifting
+  function parseWpDate(dateStr: string, dateGmtStr?: string): string {
+    if (dateGmtStr && dateGmtStr !== '0000-00-00T00:00:00') {
+      const formatted = dateGmtStr.endsWith('Z') ? dateGmtStr : `${dateGmtStr}Z`;
+      return new Date(formatted).toISOString();
+    }
+    return new Date(dateStr).toISOString();
+  }
+
+  const dateIso = parseWpDate(wpPost.date, wpPost.date_gmt);
+  const modifiedIso = parseWpDate(wpPost.modified, wpPost.modified_gmt);
+  const decodedTitle = decodeHtmlEntities(wpPost.title.rendered);
+
   // Prepend frontmatter and title heading
   const frontmatter = [
     `---`,
-    `title: "${wpPost.title.rendered.replace(/"/g, '\\"')}"`,
-    `date: "${new Date(wpPost.date).toISOString()}"`,
-    `updated: "${new Date(wpPost.modified).toISOString()}"`,
+    `title: "${decodedTitle.replace(/"/g, '\\"')}"`,
+    `date: "${dateIso}"`,
+    `updated: "${modifiedIso}"`,
     `---`,
     ``,
-    `# ${wpPost.title.rendered}`,
+    `# ${decodedTitle}`,
     ``,
     markdownBody,
     ``,
@@ -870,5 +934,3 @@ export async function pullFromWordPress({
     console.log(`\n  💾 Successfully pulled and saved post to: ${targetLocalPath}`);
   }
 }
-
-

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -461,10 +461,10 @@ export function resolveAndCollectImagePath(
       const contentPath = path.join(site.vaultPath, 'content', relPath);
       
       if (existsSync(publicPath)) {
-        return `/${relPath}`;
+        return relPath;
       }
       if (existsSync(contentPath)) {
-        return `/${relPath}`;
+        return relPath;
       }
     }
   }
@@ -480,10 +480,10 @@ export function resolveAndCollectImagePath(
       const publicPath = path.join(site.vaultPath, 'public', `${pathWithoutThumbExt}${curExt}`);
       const contentPath = path.join(site.vaultPath, 'content', `${pathWithoutThumbExt}${curExt}`);
       if (existsSync(publicPath)) {
-        return `/${pathWithoutThumbExt}${curExt}`;
+        return `${pathWithoutThumbExt}${curExt}`;
       }
       if (existsSync(contentPath)) {
-        return `/${pathWithoutThumbExt}${curExt}`;
+        return `${pathWithoutThumbExt}${curExt}`;
       }
     }
   }
@@ -504,7 +504,7 @@ export function resolveAndCollectImagePath(
     });
   }
 
-  return `/${targetLocalPath}`;
+  return targetLocalPath;
 }
 
 export function restoreLocalImagePath(src: string, site: Site, registry: Registry): string {

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -380,21 +380,38 @@ interface WpPost {
   status: string;
 }
 
-export function restoreLocalImagePath(src: string, site: Site, registry: Registry): string {
+export function resolveAndCollectImagePath(
+  src: string,
+  site: Site,
+  registry: Registry,
+  collectedImages?: { remoteUrl: string; tryHighResUrl: string; localPath: string }[]
+): string {
   // If it's a relative path already, just return it
   if (src.startsWith('/') && !src.startsWith('//') && !src.includes('/api/vault-public/') && !src.includes('_thumbnails/')) {
     return src;
   }
 
   let tempPath = src;
+  let isExternal = false;
+  const originalUrl = src;
 
-  // Remove protocol and host if present
+  // Check if it is an external URL
   if (tempPath.startsWith('http://') || tempPath.startsWith('https://')) {
     try {
       const urlObj = new URL(tempPath);
+      const isInternal = 
+        tempPath.includes('_thumbnails/') || 
+        tempPath.includes('/api/vault-public/') ||
+        (site.domain && urlObj.hostname === site.domain) ||
+        (site.imageHost && urlObj.hostname === new URL(site.imageHost).hostname) ||
+        (registry.imageHost && urlObj.hostname === new URL(registry.imageHost).hostname);
+
+      if (!isInternal) {
+        isExternal = true;
+      }
       tempPath = urlObj.pathname + urlObj.search + urlObj.hash;
     } catch {
-      // ignore
+      isExternal = true;
     }
   }
 
@@ -417,51 +434,86 @@ export function restoreLocalImagePath(src: string, site: Site, registry: Registr
     }
   }
 
-  // Now, check if it contains _thumbnails
+  // Extract filename
+  const filename = tempPath.split('/').pop() || '';
+  if (!filename) return src;
+
+  // Extract base name and extension to find original files
+  const ext = path.extname(filename);
+  const baseName = path.basename(filename, ext);
+  const cleanBaseName = baseName.replace(/-(\d+x\d+|\d+)$/, '');
+  const finalFilename = `${cleanBaseName}${ext}`;
+
+  // Check if the file already exists locally
+  const dir = path.dirname(tempPath);
+  const candidateFolders = ['attachments', 'images', dir !== '.' ? dir : '', ''];
+  const extensions = [ext, '.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif'];
+
+  for (const folder of candidateFolders) {
+    for (const curExt of extensions) {
+      const checkFilename = `${cleanBaseName}${curExt}`;
+      const relPath = folder ? `${folder}/${checkFilename}` : checkFilename;
+      
+      const publicPath = path.join(site.vaultPath, 'public', relPath);
+      const contentPath = path.join(site.vaultPath, 'content', relPath);
+      
+      if (existsSync(publicPath)) {
+        return `/${relPath}`;
+      }
+      if (existsSync(contentPath)) {
+        return `/${relPath}`;
+      }
+    }
+  }
+
+  // If it contains _thumbnails, extract path
   const thumbIndex = tempPath.indexOf('_thumbnails/');
   if (thumbIndex !== -1) {
     tempPath = tempPath.substring(thumbIndex + '_thumbnails/'.length);
-    // Strip width suffix like -1200.webp
     const match = tempPath.match(/(.+)-\d+\.webp$/);
-    if (match) {
-      tempPath = match[1];
-    } else {
-      tempPath = tempPath.replace(/\.[^/.]+$/, "");
-    }
+    const pathWithoutThumbExt = match ? match[1] : tempPath.replace(/\.[^/.]+$/, "");
 
-    // Now look on disk for the original extension
-    const extensions = ['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif', '.tiff', '.tif'];
-    for (const ext of extensions) {
-      const publicPath = path.join(site.vaultPath, 'public', `${tempPath}${ext}`);
-      const contentPath = path.join(site.vaultPath, 'content', `${tempPath}${ext}`);
+    for (const curExt of extensions) {
+      const publicPath = path.join(site.vaultPath, 'public', `${pathWithoutThumbExt}${curExt}`);
+      const contentPath = path.join(site.vaultPath, 'content', `${pathWithoutThumbExt}${curExt}`);
       if (existsSync(publicPath)) {
-        return `/${tempPath}${ext}`;
+        return `/${pathWithoutThumbExt}${curExt}`;
       }
       if (existsSync(contentPath)) {
-        return `/${tempPath}${ext}`;
+        return `/${pathWithoutThumbExt}${curExt}`;
       }
     }
-    // Fallback if not found on disk
-    return `/${tempPath}.webp`;
   }
 
-  // Even if it didn't contain _thumbnails, let's check if the file with its extension
-  // or other common extensions exists on disk
-  const basePathWithoutExt = tempPath.replace(/\.[^/.]+$/, "");
-  const extensions = ['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif', '.tiff', '.tif'];
-  for (const ext of extensions) {
-    if (existsSync(path.join(site.vaultPath, 'public', `${basePathWithoutExt}${ext}`))) {
-      return `/${basePathWithoutExt}${ext}`;
+  // If not found locally, we queue it for download
+  const targetLocalPath = `attachments/${finalFilename}`;
+  const targetFullPath = path.join(site.vaultPath, 'content', targetLocalPath);
+
+  if (collectedImages) {
+    let tryHighResUrl = originalUrl;
+    if (originalUrl.includes(filename)) {
+      tryHighResUrl = originalUrl.replace(filename, finalFilename);
     }
-    if (existsSync(path.join(site.vaultPath, 'content', `${basePathWithoutExt}${ext}`))) {
-      return `/${basePathWithoutExt}${ext}`;
-    }
+    collectedImages.push({
+      remoteUrl: originalUrl,
+      tryHighResUrl,
+      localPath: targetFullPath,
+    });
   }
 
-  return `/${tempPath}`;
+  return `/${targetLocalPath}`;
 }
 
-export function htmlToMarkdown(html: string, site: Site, registry: Registry): string {
+export function restoreLocalImagePath(src: string, site: Site, registry: Registry): string {
+  return resolveAndCollectImagePath(src, site, registry);
+}
+
+export function htmlToMarkdown(
+  html: string,
+  site: Site,
+  registry: Registry,
+  collectedImages?: { remoteUrl: string; tryHighResUrl: string; localPath: string }[]
+): string {
   // Tokenize the HTML
   const tagRegex = /(<\/?[a-zA-Z0-9:-]+(?:\s+[a-zA-Z0-9:-]+(?:=(?:"[^"]*"|'[^']*'|[^\s>]+))?)*\s*\/?>)/g;
   const parts = html.split(tagRegex);
@@ -621,7 +673,7 @@ export function htmlToMarkdown(html: string, site: Site, registry: Registry): st
       case 'img': {
         const src = node.attributes['src'] || '';
         const alt = node.attributes['alt'] || '';
-        const localSrc = restoreLocalImagePath(src, site, registry);
+        const localSrc = resolveAndCollectImagePath(src, site, registry, collectedImages);
         return `![${alt}](${localSrc})`;
       }
       case 'figure': {
@@ -632,7 +684,7 @@ export function htmlToMarkdown(html: string, site: Site, registry: Registry): st
         const figcaption = findNodeByType(node, 'figcaption');
         const captionText = figcaption ? getPlainText(figcaption).trim() : '';
         const finalAlt = alt || captionText;
-        const localSrc = restoreLocalImagePath(src, site, registry);
+        const localSrc = resolveAndCollectImagePath(src, site, registry, collectedImages);
         return `\n\n![${finalAlt}](${localSrc})\n\n`;
       }
       case 'figcaption':
@@ -730,8 +782,9 @@ export async function pullFromWordPress({
 
   console.log(`✅ Found post: "${wpPost.title.rendered}" (ID: wpPost ID: ${wpPost.id}, Slug: ${wpPost.slug})`);
 
-  // Convert HTML to Markdown
-  const markdownBody = htmlToMarkdown(wpPost.content.rendered, site, registry);
+  // Convert HTML to Markdown (and collect any remote image urls to download)
+  const collectedImages: { remoteUrl: string; tryHighResUrl: string; localPath: string }[] = [];
+  const markdownBody = htmlToMarkdown(wpPost.content.rendered, site, registry, collectedImages);
 
   // Prepend frontmatter and title heading
   const frontmatter = [
@@ -767,14 +820,51 @@ export async function pullFromWordPress({
   if (dryRun) {
     console.log(`  [DRY RUN] Would write Markdown post for "${wpPost.title.rendered}" to:`);
     console.log(`  📂 ${targetLocalPath}`);
+    if (collectedImages.length > 0) {
+      console.log(`\n  [DRY RUN] Would download ${collectedImages.length} image(s):`);
+      for (const img of collectedImages) {
+        console.log(`  - ${img.tryHighResUrl} -> ${img.localPath}`);
+      }
+    }
     console.log(`\n--- PREVIEW START ---`);
     console.log(frontmatter);
     console.log(`--- PREVIEW END ---`);
   } else {
     // Ensure parent directory exists
     await mkdir(path.dirname(targetLocalPath), { recursive: true });
+
+    // Download collected images
+    if (collectedImages.length > 0) {
+      console.log(`\n📥 Downloading ${collectedImages.length} image(s) to local vault...`);
+      for (const img of collectedImages) {
+        try {
+          await mkdir(path.dirname(img.localPath), { recursive: true });
+          console.log(`- Fetching image: ${img.tryHighResUrl}`);
+          let imgResponse = await fetch(img.tryHighResUrl);
+          
+          if (!imgResponse.ok) {
+            console.log(`  (High-res URL failed, falling back to original: ${img.remoteUrl})`);
+            imgResponse = await fetch(img.remoteUrl);
+          }
+
+          if (!imgResponse.ok) {
+            console.error(`  ❌ Failed to download image from both URLs: ${imgResponse.statusText}`);
+            continue;
+          }
+
+          const buffer = Buffer.from(await imgResponse.arrayBuffer());
+          await writeFile(img.localPath, buffer);
+          console.log(`  ✅ Saved to: ${img.localPath}`);
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          console.error(`  ❌ Failed to download image "${img.remoteUrl}":`, errMsg);
+        }
+      }
+    }
+
     await writeFile(targetLocalPath, frontmatter, 'utf-8');
-    console.log(`  💾 Successfully pulled and saved post to: ${targetLocalPath}`);
+    console.log(`\n  💾 Successfully pulled and saved post to: ${targetLocalPath}`);
   }
 }
+
 

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -531,7 +531,22 @@ export function htmlToMarkdown(html: string, site: Site, registry: Registry): st
       .replace(/&rsquo;/g, '’')
       .replace(/&ndash;/g, '–')
       .replace(/&mdash;/g, '—')
-      .replace(/&nbsp;/g, ' ');
+      .replace(/&hellip;/g, '…')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&#(\d+);/g, (_, dec) => {
+        try {
+          return String.fromCodePoint(parseInt(dec, 10));
+        } catch {
+          return _;
+        }
+      })
+      .replace(/&#x([a-fA-F0-9]+);/g, (_, hex) => {
+        try {
+          return String.fromCodePoint(parseInt(hex, 16));
+        } catch {
+          return _;
+        }
+      });
   }
 
   function render(node: Node, listDepth = 0): string {

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -384,6 +384,7 @@ export function resolveAndCollectImagePath(
   src: string,
   site: Site,
   registry: Registry,
+  slug = '',
   collectedImages?: { remoteUrl: string; tryHighResUrl: string; localPath: string }[]
 ): string {
   // If it's a relative path already, just return it
@@ -447,6 +448,9 @@ export function resolveAndCollectImagePath(
   // Check if the file already exists locally
   const dir = path.dirname(tempPath);
   const candidateFolders = ['attachments', 'images', dir !== '.' ? dir : '', ''];
+  if (slug) {
+    candidateFolders.unshift(slug);
+  }
   const extensions = [ext, '.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif'];
 
   for (const folder of candidateFolders) {
@@ -486,7 +490,7 @@ export function resolveAndCollectImagePath(
   }
 
   // If not found locally, we queue it for download
-  const targetLocalPath = `attachments/${finalFilename}`;
+  const targetLocalPath = slug ? `${slug}/${finalFilename}` : `attachments/${finalFilename}`;
   const targetFullPath = path.join(site.vaultPath, 'content', targetLocalPath);
 
   if (collectedImages) {
@@ -512,6 +516,7 @@ export function htmlToMarkdown(
   html: string,
   site: Site,
   registry: Registry,
+  slug = '',
   collectedImages?: { remoteUrl: string; tryHighResUrl: string; localPath: string }[]
 ): string {
   // Tokenize the HTML
@@ -673,7 +678,7 @@ export function htmlToMarkdown(
       case 'img': {
         const src = node.attributes['src'] || '';
         const alt = node.attributes['alt'] || '';
-        const localSrc = resolveAndCollectImagePath(src, site, registry, collectedImages);
+        const localSrc = resolveAndCollectImagePath(src, site, registry, slug, collectedImages);
         return `![${alt}](${localSrc})`;
       }
       case 'figure': {
@@ -684,7 +689,7 @@ export function htmlToMarkdown(
         const figcaption = findNodeByType(node, 'figcaption');
         const captionText = figcaption ? getPlainText(figcaption).trim() : '';
         const finalAlt = alt || captionText;
-        const localSrc = resolveAndCollectImagePath(src, site, registry, collectedImages);
+        const localSrc = resolveAndCollectImagePath(src, site, registry, slug, collectedImages);
         return `\n\n![${finalAlt}](${localSrc})\n\n`;
       }
       case 'figcaption':
@@ -784,7 +789,7 @@ export async function pullFromWordPress({
 
   // Convert HTML to Markdown (and collect any remote image urls to download)
   const collectedImages: { remoteUrl: string; tryHighResUrl: string; localPath: string }[] = [];
-  const markdownBody = htmlToMarkdown(wpPost.content.rendered, site, registry, collectedImages);
+  const markdownBody = htmlToMarkdown(wpPost.content.rendered, site, registry, wpPost.slug, collectedImages);
 
   // Prepend frontmatter and title heading
   const frontmatter = [

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -70,6 +70,19 @@ describe("createMarkdownRenderer", () => {
     expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
   });
+
+  it("consumes adjacent italicized paragraph as a custom figcaption and preserves links", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: "![My Alt Text](image.png)\n*This is my [caption link](https://example.com) text.*",
+      thumbnailSizes: [320],
+      publicFiles: ["image.png"],
+    });
+    expect(html).toContain('<figure class="image-figure">');
+    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
+    expect(html).toContain('<figcaption>This is my <a href="https://example.com">caption link</a> text.</figcaption></figure>');
+    expect(html).not.toContain('<p><em>This is my');
+  });
 });
 
 describe("preprocessWikilinks", () => {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -53,65 +53,125 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       : { class: "image-figure" };
 
     function visit(node: MarkdownNode) {
-      const nonWhitespaceChildren = node.children?.filter(
-        child => !(child.type === "text" && child.value?.trim() === "")
-      ) || [];
+      if (node.children) {
+        for (let i = 0; i < node.children.length; i++) {
+          const child = node.children[i];
+          const nonWhitespaceChildren = child.children?.filter(
+            c => !(c.type === "text" && c.value?.trim() === "")
+          ) || [];
 
-      if (node.type === "paragraph" && nonWhitespaceChildren.length === 1 && nonWhitespaceChildren[0].type === "image") {
-        const imgNode = nonWhitespaceChildren[0];
-        const imgUrl = imgNode.url || "";
-        const attributes = deps.getResponsiveImageAttributes({ src: imgUrl, thumbnailSizes });
-        const srcVal = attributes ? attributes.src : encodeURI(imgUrl);
-        const altText = imgNode.alt || '';
+          if (child.type === "paragraph" && nonWhitespaceChildren.length === 1 && nonWhitespaceChildren[0].type === "image") {
+            const imgNode = nonWhitespaceChildren[0];
+            const imgUrl = imgNode.url || "";
+            const attributes = deps.getResponsiveImageAttributes({ src: imgUrl, thumbnailSizes });
+            const srcVal = attributes ? attributes.src : encodeURI(imgUrl);
+            const altText = imgNode.alt || '';
 
-        const imgProperties: Record<string, string> = {
-          src: srcVal,
-          style: "max-width: 100%;",
-        };
-        if (altText) {
-          imgProperties.alt = altText;
-        }
-        if (attributes) {
-          imgProperties.srcset = attributes.srcSet;
-          imgProperties.sizes = `(max-width: ${largestWidth}px) 100vw, ${largestWidth}px`;
-        }
-        imgProperties.loading = "lazy";
-        imgProperties.decoding = "async";
+            const imgProperties: Record<string, string> = {
+              src: srcVal,
+              style: "max-width: 100%;",
+            };
+            if (altText) {
+              imgProperties.alt = altText;
+            }
+            if (attributes) {
+              imgProperties.srcset = attributes.srcSet;
+              imgProperties.sizes = `(max-width: ${largestWidth}px) 100vw, ${largestWidth}px`;
+            }
+            imgProperties.loading = "lazy";
+            imgProperties.decoding = "async";
 
-        const children: MarkdownNode[] = [
-          {
-            type: "element",
-            tagName: "img",
-            properties: imgProperties,
-            children: [],
-          }
-        ];
-
-        if (altText) {
-          children.push({
-            type: "element",
-            tagName: "figcaption",
-            properties: {},
-            children: [
+            const hChildren: MarkdownNode[] = [
               {
-                type: "text",
-                value: altText,
+                type: "element",
+                tagName: "img",
+                properties: imgProperties,
+                children: [],
               }
-            ],
-          });
-        }
+            ];
 
-        node.type = "image-figure";
-        node.data = {
-          ...node.data,
-          hName: "figure",
-          hProperties: {
-            ...figureProps,
-          },
-          hChildren: children,
-        };
-        delete node.children;
-        return;
+            let hasCustomCaption = false;
+            let customCaptionNode: MarkdownNode | null = null;
+            if (i + 1 < node.children.length) {
+              const nextSibling = node.children[i + 1];
+              const siblingChildren = nextSibling.children || [];
+              if (nextSibling.type === "paragraph" && siblingChildren.length === 1 && siblingChildren[0].type === "emphasis") {
+                hasCustomCaption = true;
+                customCaptionNode = siblingChildren[0];
+              }
+            }
+
+            if (hasCustomCaption && customCaptionNode) {
+              function mapMdastToHast(n: MarkdownNode): MarkdownNode {
+                if (n.type === 'text') {
+                  return { type: 'text', value: n.value };
+                }
+                if (n.type === 'link') {
+                  return {
+                    type: 'element',
+                    tagName: 'a',
+                    properties: { href: n.url || "" },
+                    children: (n.children || []).map(mapMdastToHast),
+                  };
+                }
+                if (n.type === 'strong') {
+                  return {
+                    type: 'element',
+                    tagName: 'strong',
+                    children: (n.children || []).map(mapMdastToHast),
+                  };
+                }
+                if (n.type === 'emphasis') {
+                  return {
+                    type: 'element',
+                    tagName: 'em',
+                    children: (n.children || []).map(mapMdastToHast),
+                  };
+                }
+                return {
+                  type: 'element',
+                  tagName: 'span',
+                  children: (n.children || []).map(mapMdastToHast),
+                };
+              }
+
+              hChildren.push({
+                type: "element",
+                tagName: "figcaption",
+                properties: {},
+                children: (customCaptionNode.children || []).map(mapMdastToHast),
+              });
+
+              // Remove the consumed caption sibling
+              node.children.splice(i + 1, 1);
+            } else if (altText) {
+              hChildren.push({
+                type: "element",
+                tagName: "figcaption",
+                properties: {},
+                children: [
+                  {
+                    type: "text",
+                    value: altText,
+                  }
+                ],
+              });
+            }
+
+            child.type = "image-figure";
+            child.data = {
+              ...child.data,
+              hName: "figure",
+              hProperties: {
+                ...figureProps,
+              },
+              hChildren,
+            };
+            delete child.children;
+          } else {
+            visit(child);
+          }
+        }
       }
 
       if (node.type === "image" && node.url) {
@@ -130,10 +190,6 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
             },
           };
         }
-      }
-
-      for (const child of node.children || []) {
-        visit(child);
       }
     }
 


### PR DESCRIPTION
This PR adds support for pulling WordPress posts by slug or numeric ID using the Notopress CLI, converting the HTML to clean Markdown, and storing them in the local vault. 

### Key Features:
1. **Custom HTML-to-Markdown Parser (`htmlToMarkdown`)**:
   - Implemented a dependency-free AST-based HTML-to-Markdown parser.
   - Converts standard HTML tags (headings, paragraphs, lists, links, inline formats, blockquotes, code blocks, figures) into clean, standard Markdown.
   - Safely decodes both named and numeric HTML entities (such as en-dash `&#8211;` -> `–` and ellipsis `&hellip;` -> `…`).
2. **Local Image Mapping (`restoreLocalImagePath`)**:
   - Resolves absolute CDN/thumbnail URLs (such as `.../_thumbnails/pic-640.webp`) back to their original local asset path (such as `/images/pic.png` or `/images/pic.jpg`) by inspecting the files in your local vault.
   - Retains the local file as the single source of truth so responsive WebP thumbnails are automatically re-created and uploaded on the next sync/push.
3. **Overwriting Support**:
   - Compares the post slug against existing local indexes to overwrite matching files in place (retaining their directory placement) or defaults to `content/<slug>.md`.
4. **CLI Integration**:
   - Added `--pull <slug-or-id>` to the sync CLI command.
   - Local vault folders are scanned in dry-run mode to discover paths before performing the pull.

### Verification:
- Added 13 new unit tests in `scripts/lib/wordpress.test.ts` covering entity decoding, custom HTML-to-Markdown parsing, image resolution, and API pulling logic.
- Type-checking (`npm run type-check`) and test suite (`npm run test`) pass cleanly.
- Verified a full round-trip pull -> Markdown -> push cycle of the `country-calling-codes` post from `chuchu.tw` with 100% plain text match.
