### PR TITLE
[codex] Fix WordPress Markdown publishing blocks and assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "remark": "^15.0.1",
+        "remark-gfm": "^4.0.1",
         "remark-html": "^16.0.1",
         "sharp": "^0.34.5",
         "zod": "^4.3.6"
@@ -1863,7 +1864,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -9066,7 +9066,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -11987,6 +11986,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11995,6 +12004,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -12015,6 +12052,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12192,6 +12330,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -13724,6 +13983,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-html": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-16.0.1.tgz",
@@ -14085,7 +14362,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -14129,7 +14405,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "remark": "^15.0.1",
+    "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",
     "sharp": "^0.34.5",
     "zod": "^4.3.6"

--- a/scripts/lib/indices.test.ts
+++ b/scripts/lib/indices.test.ts
@@ -41,8 +41,8 @@ describe('createIndexGenerator', () => {
           ? { data: { title: 'Home', date: '2024-01-02' }, content: '# Home\nIntro text' }
           : { data: {}, content: '# Post\nPost excerpt' },
       normalizeThumbnailSizes: (sizes) => [...(sizes || [])],
-      scanPublicFiles: vi.fn(async () => ['sitemap.xml']),
-      scanContentAssetFiles: vi.fn(async () => ['hero.png']),
+      scanPublicFiles: vi.fn(async () => ['sitemap.xml', '_thumbnails/logo-320.webp']),
+      scanContentAssetFiles: vi.fn(async () => ['hero.png', '_thumbnails/hero-320.webp']),
       generateImageThumbnails,
       logger,
     });
@@ -57,7 +57,8 @@ describe('createIndexGenerator', () => {
     expect(result.allIndices.get('blog')?.pages[0].slug).toBe('post');
     expect(JSON.parse(writes['vault/root.json'])).toMatchObject({
       directories: ['blog'],
-      publicFiles: ['hero.png', 'sitemap.xml'],
+      publicFiles: ['sitemap.xml'],
+      assetFiles: ['hero.png', 'sitemap.xml'],
       thumbnailSizes: [320, 640],
     });
     expect(generateImageThumbnails).toHaveBeenCalledWith({

--- a/scripts/lib/indices.ts
+++ b/scripts/lib/indices.ts
@@ -5,7 +5,7 @@ import { type Stats } from 'fs';
 import path from 'path';
 import { INDEX_JSON, ROOT_JSON } from '../../src/lib/constants';
 import { PageMetadata, VaultDirectoryIndex, VaultRootIndex } from '../../src/lib/vault';
-import { normalizeThumbnailSizes } from '../../src/lib/responsive-images';
+import { isGeneratedThumbnailPath, normalizeThumbnailSizes } from '../../src/lib/responsive-images';
 import { exists, scanContentAssetFiles, scanPublicFiles, type FileEntry } from './files';
 import { generateImageThumbnails } from './thumbnails';
 
@@ -71,6 +71,10 @@ function parseSafeDate({
   }
 
   return date.toISOString();
+}
+
+function excludeGeneratedFiles(files: readonly string[]): string[] {
+  return files.filter((file) => !isGeneratedThumbnailPath(file));
 }
 
 export function createIndexGenerator(deps: IndexGeneratorDeps) {
@@ -218,15 +222,18 @@ export function createIndexGenerator(deps: IndexGeneratorDeps) {
         label: 'public',
       });
 
-      const publicFiles = (await deps.exists(publicBaseDir)) ? await deps.scanPublicFiles({ dir: publicBaseDir }) : [];
-      const contentAssetFiles = await deps.scanContentAssetFiles({ dir: contentDir });
+      const publicFiles = excludeGeneratedFiles(
+        (await deps.exists(publicBaseDir)) ? await deps.scanPublicFiles({ dir: publicBaseDir }) : []
+      ).sort();
+      const contentAssetFiles = excludeGeneratedFiles(await deps.scanContentAssetFiles({ dir: contentDir }));
       const assetFiles = [...new Set([...publicFiles, ...contentAssetFiles])].sort();
 
       const rootPath = deps.joinPath(vaultPath, ROOT_JSON);
       const vaultRootIndex: VaultRootIndex = {
         ...rootContentIndex,
         directories: allDirs,
-        publicFiles: assetFiles,
+        publicFiles,
+        assetFiles,
         thumbnailSizes: deps.normalizeThumbnailSizes(thumbnailSizes),
       };
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -109,6 +109,27 @@ describe('WordPress Deployment Library', () => {
       expect(result).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp"');
     });
 
+    it('should resolve encoded root-level image references to attachment thumbnails without double encoding', async () => {
+      const html = '<img src="/Pasted%2520image%252020260630150256.png" alt="Cable status" />';
+      const sizes = [300, 600, 1200];
+
+      const result = await replaceLocalImagesWithThumbnails({
+        html,
+        site: mockSite,
+        registry: mockRegistry,
+        sizes,
+        assetFiles: ['attachments/Pasted image 20260630150256.png'],
+      });
+
+      expect(result).toContain(
+        'src="https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-1200.webp"'
+      );
+      expect(result).toContain(
+        'srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-1200.webp 1200w"'
+      );
+      expect(result).not.toContain('%2520');
+    });
+
     it('should ignore external URLs and data URIs', async () => {
       const html = `
         <img src="https://external.com/photo.jpg" alt="Ext" />
@@ -525,4 +546,3 @@ describe('WordPress Deployment Library', () => {
     });
   });
 });
-

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -261,6 +261,47 @@ describe('WordPress Deployment Library', () => {
       );
     });
 
+    it('should publish markdown tables as striped WordPress table figures', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 789 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+      vi.mocked(readFile).mockResolvedValue([
+        '# My Post Title',
+        '',
+        '| Name | Value |',
+        '| --- | --- |',
+        '| A | B |',
+      ].join('\n'));
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetPostSlug: 'post-one',
+        dryRun: false,
+      });
+
+      const postCall = mockFetch.mock.calls.find((call) => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body);
+      expect(body.content).toContain('<figure class="wp-block-table is-style-stripes">');
+      expect(body.content).toContain('<table>');
+      expect(body.content).toContain('</table>\n</figure>');
+    });
+
     it('should only query and perform no mutations when dryRun is true', async () => {
       const mockFetch = vi.fn().mockImplementation(async (url, options) => {
         if (url.includes('/wp/v2/posts') && options.method === 'GET') {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -297,9 +297,11 @@ describe('WordPress Deployment Library', () => {
       const postCall = mockFetch.mock.calls.find((call) => call[1]?.method === 'POST');
       expect(postCall).toBeDefined();
       const body = JSON.parse(postCall![1].body);
+      expect(body.content).toContain('<!-- wp:table {"className":"is-style-stripes"} -->');
       expect(body.content).toContain('<figure class="wp-block-table is-style-stripes">');
       expect(body.content).toContain('<table>');
       expect(body.content).toContain('</table>\n</figure>');
+      expect(body.content).toContain('<!-- /wp:table -->');
     });
 
     it('should only query and perform no mutations when dryRun is true', async () => {

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -6,6 +6,7 @@ import { getAssetSubDir } from './files';
 import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
+import { serializeHtmlToWordPressBlocks } from '../../src/lib/wordpress-blocks';
 import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl, RESPONSIVE_IMAGE_SIZES } from '../../src/lib/responsive-images';
 import { isExternalOrInlineAsset, resolveLocalImagePath } from '../../src/lib/local-images';
 
@@ -309,6 +310,7 @@ export async function pushToWordPress({
         sizes,
         assetFiles,
       });
+      const wordpressBlockContent = serializeHtmlToWordPressBlocks(htmlContent);
 
       // Replace slashes with hyphens to match WordPress's sanitization behavior
       const wpSlug = post.slug.replace(/\//g, '-');
@@ -325,7 +327,7 @@ export async function pushToWordPress({
 
       const payload = {
         title: post.title,
-        content: htmlContent,
+        content: wordpressBlockContent,
         slug: wpSlug,
         status: 'publish',
         date: post.date,

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -7,6 +7,7 @@ import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
 import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl, RESPONSIVE_IMAGE_SIZES } from '../../src/lib/responsive-images';
+import { isExternalOrInlineAsset, resolveLocalImagePath } from '../../src/lib/local-images';
 
 
 interface PushToWordPressArgs {
@@ -69,11 +70,13 @@ export async function replaceLocalImagesWithThumbnails({
   site,
   registry,
   sizes,
+  assetFiles,
 }: {
   html: string;
   site: Site;
   registry: Registry;
   sizes: readonly number[];
+  assetFiles?: readonly string[];
 }): Promise<string> {
   const imageHost = site.imageHost || registry.imageHost;
   const largestWidth = sizes[sizes.length - 1];
@@ -99,20 +102,14 @@ export async function replaceLocalImagesWithThumbnails({
 
   for (const { fullMatch, src } of uniqueMatches) {
     // Skip external or inline assets
-    if (
-      src.startsWith('http://') ||
-      src.startsWith('https://') ||
-      src.startsWith('data:') ||
-      src.startsWith('#')
-    ) {
+    if (isExternalOrInlineAsset({ src })) {
       continue;
     }
 
-    const cleanSrc = src.replace(/^\//, '');
-    const decodedSrc = decodeURIComponent(cleanSrc);
+    const imagePath = resolveLocalImagePath({ src, availableFiles: assetFiles });
 
     // Get the thumbnail filename and relative directory path
-    const thumbPath = getThumbnailPath({ imagePath: decodedSrc, width: largestWidth });
+    const thumbPath = getThumbnailPath({ imagePath, width: largestWidth });
 
     // Determine target location in S3 by checking local filesystem existence
     const s3SubDir = await getAssetSubDir({ vaultPath: site.vaultPath, filePath: thumbPath });
@@ -128,7 +125,7 @@ export async function replaceLocalImagesWithThumbnails({
 
     // Build the srcset attributes for all defined thumbnail sizes
     const srcSetUrls = sizes.map((size) => {
-      const sizeThumbPath = getThumbnailPath({ imagePath: decodedSrc, width: size });
+      const sizeThumbPath = getThumbnailPath({ imagePath, width: size });
       const sizeUrl = getAssetUrl({
         imageHost,
         siteId: site.siteId,
@@ -305,6 +302,7 @@ export async function pushToWordPress({
         site,
         registry,
         sizes,
+        assetFiles: publicFiles,
       });
 
       // Replace slashes with hyphens to match WordPress's sanitization behavior

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -213,11 +213,11 @@ export async function pushToWordPress({
   console.log(dryRun ? `- Mode: DRY RUN (No changes will be written)\n` : `- Mode: Live Sync\n`);
 
   // Load public files from root.json if it exists
-  let publicFiles: string[] = [];
+  let assetFiles: string[] = [];
   try {
     const rootIndexRaw = await readFile(path.join(site.vaultPath, 'root.json'), 'utf-8');
     const rootIndex = JSON.parse(rootIndexRaw);
-    publicFiles = rootIndex.publicFiles || [];
+    assetFiles = rootIndex.assetFiles || rootIndex.publicFiles || [];
   } catch (err) {
     // If root.json is not found or not yet generated, fallback to empty array
   }
@@ -287,7 +287,7 @@ export async function pushToWordPress({
       let htmlContent = await renderMarkdownContent({
         markdown: bodyWithoutTitle,
         thumbnailSizes: sizes,
-        publicFiles,
+        assetFiles,
         getFigureProperties: (largestWidth) => {
           return {
             class: 'wp-block-image',
@@ -302,7 +302,7 @@ export async function pushToWordPress({
         site,
         registry,
         sizes,
-        assetFiles: publicFiles,
+        assetFiles,
       });
 
       // Replace slashes with hyphens to match WordPress's sanitization behavior

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -294,6 +294,11 @@ export async function pushToWordPress({
             style: 'height: auto !important;',
           };
         },
+        getTableFigureProperties: () => {
+          return {
+            class: 'wp-block-table is-style-stripes',
+          };
+        },
       });
 
       // Replace local image paths with imageHost absolute thumbnail URLs

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -69,12 +69,12 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
     const bodyWithoutTitle = markdownBody.replace(/^#\s+.+$/m, "").trim();
 
     const rootIndex = await fetchRootIndex(vaultConfig);
-    const publicFiles = rootIndex?.publicFiles || [];
+    const assetFiles = rootIndex?.assetFiles || rootIndex?.publicFiles || [];
 
     const contentHtml = await renderMarkdownContent({
       markdown: bodyWithoutTitle,
       thumbnailSizes: result.thumbnailSizes,
-      publicFiles,
+      assetFiles,
     });
     const { metadata } = result;
 

--- a/src/lib/local-images.test.ts
+++ b/src/lib/local-images.test.ts
@@ -34,6 +34,11 @@ describe("local image helpers", () => {
     ).toBe("logo.png");
   });
 
+  it("uses an updated index when a different available file list is provided", () => {
+    expect(resolveLocalImagePath({ src: "/logo.png", availableFiles: ["brand/logo.png"] })).toBe("brand/logo.png");
+    expect(resolveLocalImagePath({ src: "/logo.png", availableFiles: ["legacy/logo.png"] })).toBe("legacy/logo.png");
+  });
+
   it("rewrites local markdown image references while leaving external images alone", () => {
     const markdown = "![A](/Pasted%20image%2020260630150256.png)\n![Remote](https://example.com/image.png)";
 

--- a/src/lib/local-images.test.ts
+++ b/src/lib/local-images.test.ts
@@ -25,6 +25,15 @@ describe("local image helpers", () => {
     expect(resolveLocalImagePath({ src: "/images/logo.png", availableFiles })).toBe("images/logo.png");
   });
 
+  it("keeps unresolved paths unchanged when a basename match is ambiguous", () => {
+    expect(
+      resolveLocalImagePath({
+        src: "/logo.png",
+        availableFiles: ["brand/logo.png", "legacy/logo.png"],
+      })
+    ).toBe("logo.png");
+  });
+
   it("rewrites local markdown image references while leaving external images alone", () => {
     const markdown = "![A](/Pasted%20image%2020260630150256.png)\n![Remote](https://example.com/image.png)";
 

--- a/src/lib/local-images.test.ts
+++ b/src/lib/local-images.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveLocalImagePath, resolveMarkdownImagePaths, safelyDecodeUriComponent } from "./local-images";
+
+describe("local image helpers", () => {
+  const availableFiles = [
+    "attachments/Pasted image 20260630150256.png",
+    "images/logo.png",
+    "direct.png",
+  ];
+
+  it("decodes repeatedly until URI components are stable", () => {
+    expect(safelyDecodeUriComponent({ value: "Pasted%2520image.png" })).toBe("Pasted image.png");
+  });
+
+  it("resolves root-level references to known attachment files", () => {
+    expect(
+      resolveLocalImagePath({
+        src: "/Pasted%2520image%252020260630150256.png",
+        availableFiles,
+      })
+    ).toBe("attachments/Pasted image 20260630150256.png");
+  });
+
+  it("keeps direct known paths unchanged", () => {
+    expect(resolveLocalImagePath({ src: "/images/logo.png", availableFiles })).toBe("images/logo.png");
+  });
+
+  it("rewrites local markdown image references while leaving external images alone", () => {
+    const markdown = "![A](/Pasted%20image%2020260630150256.png)\n![Remote](https://example.com/image.png)";
+
+    expect(resolveMarkdownImagePaths({ markdown, availableFiles })).toBe(
+      "![A](<attachments/Pasted image 20260630150256.png>)\n![Remote](https://example.com/image.png)"
+    );
+  });
+});

--- a/src/lib/local-images.ts
+++ b/src/lib/local-images.ts
@@ -23,6 +23,36 @@ export function isExternalOrInlineAsset({ src }: { src: string }): boolean {
   );
 }
 
+type LocalImageIndex = {
+  availableFileSet: ReadonlySet<string>;
+  filesByBasename: ReadonlyMap<string, readonly string[]>;
+};
+
+const imageIndexCache = new WeakMap<readonly string[], LocalImageIndex>();
+
+function getLocalImageIndex(availableFiles: readonly string[]): LocalImageIndex {
+  const cachedIndex = imageIndexCache.get(availableFiles);
+  if (cachedIndex) {
+    return cachedIndex;
+  }
+
+  const basenameMap = new Map<string, string[]>();
+  for (const file of availableFiles) {
+    const fileParts = file.split("/");
+    const basename = fileParts[fileParts.length - 1] || file;
+    const matches = basenameMap.get(basename) || [];
+    matches.push(file);
+    basenameMap.set(basename, matches);
+  }
+
+  const index: LocalImageIndex = {
+    availableFileSet: new Set(availableFiles),
+    filesByBasename: basenameMap,
+  };
+  imageIndexCache.set(availableFiles, index);
+  return index;
+}
+
 export function resolveLocalImagePath({
   src,
   availableFiles,
@@ -35,17 +65,14 @@ export function resolveLocalImagePath({
     return cleanSrc;
   }
 
-  const availableFileSet = new Set(availableFiles);
-  if (availableFileSet.has(cleanSrc)) {
+  const imageIndex = getLocalImageIndex(availableFiles);
+  if (imageIndex.availableFileSet.has(cleanSrc)) {
     return cleanSrc;
   }
 
   const pathParts = cleanSrc.split("/");
   const basename = pathParts[pathParts.length - 1] || cleanSrc;
-  const basenameMatches = availableFiles.filter((file) => {
-    const fileParts = file.split("/");
-    return fileParts[fileParts.length - 1] === basename;
-  });
+  const basenameMatches = imageIndex.filesByBasename.get(basename) || [];
 
   return basenameMatches.length === 1 ? basenameMatches[0] : cleanSrc;
 }

--- a/src/lib/local-images.ts
+++ b/src/lib/local-images.ts
@@ -1,5 +1,3 @@
-const DEFAULT_LOCAL_IMAGE_FOLDERS = ["attachments", "images"] as const;
-
 export function safelyDecodeUriComponent({ value, maxPasses = 3 }: { value: string; maxPasses?: number }): string {
   let decodedValue = value;
   for (let attempt = 0; attempt < maxPasses; attempt += 1) {
@@ -28,11 +26,9 @@ export function isExternalOrInlineAsset({ src }: { src: string }): boolean {
 export function resolveLocalImagePath({
   src,
   availableFiles,
-  lookupFolders = DEFAULT_LOCAL_IMAGE_FOLDERS,
 }: {
   src: string;
   availableFiles?: readonly string[];
-  lookupFolders?: readonly string[];
 }): string {
   const cleanSrc = safelyDecodeUriComponent({ value: src.replace(/^\//, "") });
   if (!availableFiles || availableFiles.length === 0) {
@@ -40,17 +36,18 @@ export function resolveLocalImagePath({
   }
 
   const availableFileSet = new Set(availableFiles);
+  if (availableFileSet.has(cleanSrc)) {
+    return cleanSrc;
+  }
+
   const pathParts = cleanSrc.split("/");
   const basename = pathParts[pathParts.length - 1] || cleanSrc;
-  const candidates = [
-    cleanSrc,
-    ...lookupFolders.map((folder) => `${folder}/${basename}`),
-    basename,
-  ].filter((candidate, index, candidates): candidate is string => {
-    return candidate.length > 0 && candidates.indexOf(candidate) === index;
+  const basenameMatches = availableFiles.filter((file) => {
+    const fileParts = file.split("/");
+    return fileParts[fileParts.length - 1] === basename;
   });
 
-  return candidates.find((candidate) => availableFileSet.has(candidate)) || cleanSrc;
+  return basenameMatches.length === 1 ? basenameMatches[0] : cleanSrc;
 }
 
 export function resolveMarkdownImagePaths({

--- a/src/lib/local-images.ts
+++ b/src/lib/local-images.ts
@@ -1,0 +1,74 @@
+const DEFAULT_LOCAL_IMAGE_FOLDERS = ["attachments", "images"] as const;
+
+export function safelyDecodeUriComponent({ value, maxPasses = 3 }: { value: string; maxPasses?: number }): string {
+  let decodedValue = value;
+  for (let attempt = 0; attempt < maxPasses; attempt += 1) {
+    try {
+      const nextValue = decodeURIComponent(decodedValue);
+      if (nextValue === decodedValue) {
+        return decodedValue;
+      }
+      decodedValue = nextValue;
+    } catch {
+      return decodedValue;
+    }
+  }
+  return decodedValue;
+}
+
+export function isExternalOrInlineAsset({ src }: { src: string }): boolean {
+  return (
+    src.startsWith("http://") ||
+    src.startsWith("https://") ||
+    src.startsWith("data:") ||
+    src.startsWith("#")
+  );
+}
+
+export function resolveLocalImagePath({
+  src,
+  availableFiles,
+  lookupFolders = DEFAULT_LOCAL_IMAGE_FOLDERS,
+}: {
+  src: string;
+  availableFiles?: readonly string[];
+  lookupFolders?: readonly string[];
+}): string {
+  const cleanSrc = safelyDecodeUriComponent({ value: src.replace(/^\//, "") });
+  if (!availableFiles || availableFiles.length === 0) {
+    return cleanSrc;
+  }
+
+  const availableFileSet = new Set(availableFiles);
+  const pathParts = cleanSrc.split("/");
+  const basename = pathParts[pathParts.length - 1] || cleanSrc;
+  const candidates = [
+    cleanSrc,
+    ...lookupFolders.map((folder) => `${folder}/${basename}`),
+    basename,
+  ].filter((candidate, index, candidates): candidate is string => {
+    return candidate.length > 0 && candidates.indexOf(candidate) === index;
+  });
+
+  return candidates.find((candidate) => availableFileSet.has(candidate)) || cleanSrc;
+}
+
+export function resolveMarkdownImagePaths({
+  markdown,
+  availableFiles,
+}: {
+  markdown: string;
+  availableFiles: readonly string[];
+}): string {
+  return markdown.replace(/!\[([^\]]*)\]\((<[^>]+>|[^)\s]+)([^)]*)\)/g, (match, alt, rawUrl, suffix) => {
+    const url = rawUrl.startsWith("<") && rawUrl.endsWith(">") ? rawUrl.slice(1, -1) : rawUrl;
+    if (isExternalOrInlineAsset({ src: url })) {
+      return match;
+    }
+
+    const resolvedPath = resolveLocalImagePath({ src: url, availableFiles });
+    const trimmedSuffix = suffix.trim();
+    const suffixText = trimmedSuffix ? ` ${trimmedSuffix}` : "";
+    return `![${alt}](<${resolvedPath}>${suffixText})`;
+  });
+}

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -46,6 +46,18 @@ describe("createMarkdownRenderer", () => {
     expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
   });
 
+  it("resolves standard markdown image references through known asset files", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: "![Cable status](/Pasted%20image%2020260630150256.png)",
+      thumbnailSizes: [320],
+      publicFiles: ["attachments/Pasted image 20260630150256.png"],
+    });
+
+    expect(html).toContain('src="/attachments/Pasted%20image%2020260630150256.png"');
+    expect(html).toContain('srcset="/_thumbnails/attachments/Pasted%20image%2020260630150256-320.webp 320w"');
+  });
+
   it("separates block-level images from adjacent text blocks", async () => {
     const { renderMarkdownContent } = await import("./markdown");
     const html = await renderMarkdownContent({
@@ -93,4 +105,3 @@ describe("preprocessWikilinks", () => {
     expect(result).toBe("Hello ![](</attachments/screenshot.png>) and ![My Alt Text](</attachments/screenshot.png>)");
   });
 });
-

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -58,7 +58,7 @@ describe("createMarkdownRenderer", () => {
     expect(html).toContain('srcset="/_thumbnails/attachments/Pasted%20image%2020260630150256-320.webp 320w"');
   });
 
-  it("renders GitHub-Flavored Markdown tables as HTML tables", async () => {
+  it("renders GitHub-Flavored Markdown tables inside generic figures", async () => {
     const { renderMarkdownContent } = await import("./markdown");
     const html = await renderMarkdownContent({
       markdown: [
@@ -69,10 +69,28 @@ describe("createMarkdownRenderer", () => {
       thumbnailSizes: [320],
     });
 
+    expect(html).toContain("<figure>\n<table>");
     expect(html).toContain("<table>");
+    expect(html).toContain("</table>\n</figure>");
+    expect(html).not.toContain("wp-block-table");
     expect(html).toContain("<th align=\"left\">VPN 品牌</th>");
     expect(html).toContain("<td align=\"center\">10 台裝置</td>");
     expect(html).toContain("<strong><a href=\"https://example.com/nord\">NordVPN</a></strong>");
+  });
+
+  it("applies custom table figure properties when provided", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: [
+        "| Name | Value |",
+        "| --- | --- |",
+        "| A | B |",
+      ].join("\n"),
+      thumbnailSizes: [320],
+      getTableFigureProperties: () => ({ class: 'custom-table', style: 'overflow-x: auto;' }),
+    });
+
+    expect(html).toContain('<figure class="custom-table" style="overflow-x: auto;">');
   });
 
   it("separates block-level images from adjacent text blocks", async () => {

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -39,7 +39,7 @@ describe("createMarkdownRenderer", () => {
     const html = await renderMarkdownContent({
       markdown: "![My Alt Text](image.png)",
       thumbnailSizes: [320],
-      publicFiles: ["image.png"],
+      assetFiles: ["image.png"],
     });
     expect(html).toContain('<figure class="image-figure">');
     expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
@@ -51,11 +51,28 @@ describe("createMarkdownRenderer", () => {
     const html = await renderMarkdownContent({
       markdown: "![Cable status](/Pasted%20image%2020260630150256.png)",
       thumbnailSizes: [320],
-      publicFiles: ["attachments/Pasted image 20260630150256.png"],
+      assetFiles: ["attachments/Pasted image 20260630150256.png"],
     });
 
     expect(html).toContain('src="/attachments/Pasted%20image%2020260630150256.png"');
     expect(html).toContain('srcset="/_thumbnails/attachments/Pasted%20image%2020260630150256-320.webp 320w"');
+  });
+
+  it("renders GitHub-Flavored Markdown tables as HTML tables", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: [
+        "| VPN 品牌 | 裝置限制 |",
+        "| :--- | :---: |",
+        "| **[NordVPN](https://example.com/nord)** | 10 台裝置 |",
+      ].join("\n"),
+      thumbnailSizes: [320],
+    });
+
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th align=\"left\">VPN 品牌</th>");
+    expect(html).toContain("<td align=\"center\">10 台裝置</td>");
+    expect(html).toContain("<strong><a href=\"https://example.com/nord\">NordVPN</a></strong>");
   });
 
   it("separates block-level images from adjacent text blocks", async () => {
@@ -63,7 +80,7 @@ describe("createMarkdownRenderer", () => {
     const html = await renderMarkdownContent({
       markdown: "Some text before\n![My Alt Text](image.png)\nSome text after",
       thumbnailSizes: [320],
-      publicFiles: ["image.png"],
+      assetFiles: ["image.png"],
     });
     expect(html).toContain("<p>Some text before</p>");
     expect(html).toContain('<figure class="image-figure">');
@@ -76,7 +93,7 @@ describe("createMarkdownRenderer", () => {
     const html = await renderMarkdownContent({
       markdown: "  ![My Alt Text](image.png) \n ",
       thumbnailSizes: [320],
-      publicFiles: ["image.png"],
+      assetFiles: ["image.png"],
     });
     expect(html).toContain('<figure class="image-figure">');
     expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
@@ -88,7 +105,7 @@ describe("createMarkdownRenderer", () => {
     const html = await renderMarkdownContent({
       markdown: "![My Alt Text](image.png)\n*This is my [caption link](https://example.com) text.*",
       thumbnailSizes: [320],
-      publicFiles: ["image.png"],
+      assetFiles: ["image.png"],
     });
     expect(html).toContain('<figure class="image-figure">');
     expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
@@ -98,10 +115,10 @@ describe("createMarkdownRenderer", () => {
 });
 
 describe("preprocessWikilinks", () => {
-  it("converts Obsidian wikilinks to standard markdown image tags using publicFiles", () => {
+  it("converts Obsidian wikilinks to standard markdown image tags using available asset files", () => {
     const markdown = "Hello ![[screenshot.png]] and ![[screenshot.png|My Alt Text]]";
-    const publicFiles = ["attachments/screenshot.png"];
-    const result = preprocessWikilinks(markdown, publicFiles);
+    const assetFiles = ["attachments/screenshot.png"];
+    const result = preprocessWikilinks(markdown, assetFiles);
     expect(result).toBe("Hello ![](</attachments/screenshot.png>) and ![My Alt Text](</attachments/screenshot.png>)");
   });
 });

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -93,6 +93,14 @@ describe("createMarkdownRenderer", () => {
     expect(html).toContain('<figure class="custom-table" style="overflow-x: auto;">');
   });
 
+  it("does not wrap tables already inside figures with long attributes", async () => {
+    const { wrapTablesInFigures } = await import("./markdown");
+    const figureClass = "wp-block-table is-style-stripes has-fixed-layout alignwide custom-long-class-name";
+    const html = `<figure class="${figureClass}" data-description="this attribute is intentionally long enough to exceed the old lookbehind window"><table><tbody><tr><td>A</td></tr></tbody></table></figure>`;
+
+    expect(wrapTablesInFigures(html, () => ({ class: "wp-block-table" }))).toBe(html);
+  });
+
   it("separates block-level images from adjacent text blocks", async () => {
     const { renderMarkdownContent } = await import("./markdown");
     const html = await renderMarkdownContent({

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -32,10 +32,44 @@ export type MarkdownRendererDeps = {
   processMarkdown: ({ markdown, plugin }: { markdown: string; plugin: Plugin<[], MarkdownNode> }) => Promise<string>;
 };
 
+export type FigureProperties = { class?: string; style?: string };
+
 export function ensureImageBlockSeparation(markdown: string): string {
   // Matches markdown images that occupy a single line on their own (with optional spaces/tabs)
   // E.g., `![alt](url)` or standard markdown links
   return markdown.replace(/(?:^|\n)([ \t]*!\[[^\]]*\]\([^)]+\)[ \t]*)(?=\n|$)/g, '\n\n$1\n\n');
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function serializeFigureProperties(properties: FigureProperties): string {
+  const attributes = Object.entries(properties)
+    .filter((entry): entry is [keyof FigureProperties, string] => typeof entry[1] === "string" && entry[1].length > 0)
+    .map(([key, value]) => `${key}="${escapeHtmlAttribute(value)}"`);
+
+  return attributes.length > 0 ? ` ${attributes.join(" ")}` : "";
+}
+
+export function wrapTablesInFigures(
+  htmlContent: string,
+  getFigureProperties?: () => FigureProperties,
+): string {
+  return htmlContent.replace(/<table(?:\s[^>]*)?>[\s\S]*?<\/table>/g, (tableHtml, offset, fullHtml) => {
+    const precedingHtml = fullHtml.slice(Math.max(0, offset - 80), offset);
+    if (/<figure\b[^>]*>\s*$/i.test(precedingHtml)) {
+      return tableHtml;
+    }
+
+    const properties = getFigureProperties ? getFigureProperties() : {};
+    const attributes = serializeFigureProperties(properties);
+    return `<figure${attributes}>\n${tableHtml}\n</figure>`;
+  });
 }
 
 export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
@@ -46,7 +80,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
   }: {
     tree: MarkdownNode;
     thumbnailSizes: readonly number[];
-    getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
+    getFigureProperties?: (largestWidth: number) => FigureProperties;
   }) {
     const normalizedSizes = normalizeThumbnailSizes(thumbnailSizes);
     const largestWidth = normalizedSizes[normalizedSizes.length - 1] || 768;
@@ -203,7 +237,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
     getFigureProperties,
   }: {
     thumbnailSizes: readonly number[];
-    getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
+    getFigureProperties?: (largestWidth: number) => FigureProperties;
   }): Plugin<[], MarkdownNode> {
     return function transformResponsiveImages() {
       return function transformer(tree: MarkdownNode) {
@@ -221,12 +255,14 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       assetFiles,
       publicFiles,
       getFigureProperties,
+      getTableFigureProperties,
     }: {
       markdown: string;
       thumbnailSizes: readonly number[];
       assetFiles?: readonly string[];
       publicFiles?: readonly string[];
-      getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
+      getFigureProperties?: (largestWidth: number) => FigureProperties;
+      getTableFigureProperties?: () => FigureProperties;
     }): Promise<string> {
       const availableFiles = assetFiles || publicFiles;
       let preprocessed = availableFiles ? preprocessWikilinks(markdown, availableFiles) : markdown;
@@ -235,7 +271,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       return deps.processMarkdown({
         markdown: preprocessed,
         plugin: responsiveImagePlugin({ thumbnailSizes, getFigureProperties }),
-      });
+      }).then((htmlContent) => wrapTablesInFigures(htmlContent, getTableFigureProperties));
     },
   };
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -61,8 +61,10 @@ export function wrapTablesInFigures(
   getFigureProperties?: () => FigureProperties,
 ): string {
   return htmlContent.replace(/<table(?:\s[^>]*)?>[\s\S]*?<\/table>/g, (tableHtml, offset, fullHtml) => {
-    const precedingHtml = fullHtml.slice(Math.max(0, offset - 80), offset);
-    if (/<figure\b[^>]*>\s*$/i.test(precedingHtml)) {
+    const precedingHtml = fullHtml.slice(0, offset);
+    const lastFigureOpenIndex = precedingHtml.search(/<figure\b[^>]*>\s*$/i);
+    const lastFigureCloseIndex = precedingHtml.lastIndexOf("</figure>");
+    if (lastFigureOpenIndex > lastFigureCloseIndex) {
       return tableHtml;
     }
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,5 +1,6 @@
 import { remark } from "remark";
 import html from "remark-html";
+import gfm from "remark-gfm";
 import type { Plugin } from "unified";
 import { getResponsiveImageAttributes, normalizeThumbnailSizes } from "./responsive-images";
 import { resolveMarkdownImagePaths } from "./local-images";
@@ -217,16 +218,19 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
     renderMarkdownContent({
       markdown,
       thumbnailSizes,
+      assetFiles,
       publicFiles,
       getFigureProperties,
     }: {
       markdown: string;
       thumbnailSizes: readonly number[];
+      assetFiles?: readonly string[];
       publicFiles?: readonly string[];
       getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
     }): Promise<string> {
-      let preprocessed = publicFiles ? preprocessWikilinks(markdown, publicFiles) : markdown;
-      preprocessed = publicFiles ? resolveMarkdownImagePaths({ markdown: preprocessed, availableFiles: publicFiles }) : preprocessed;
+      const availableFiles = assetFiles || publicFiles;
+      let preprocessed = availableFiles ? preprocessWikilinks(markdown, availableFiles) : markdown;
+      preprocessed = availableFiles ? resolveMarkdownImagePaths({ markdown: preprocessed, availableFiles }) : preprocessed;
       preprocessed = ensureImageBlockSeparation(preprocessed);
       return deps.processMarkdown({
         markdown: preprocessed,
@@ -236,7 +240,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
   };
 }
 
-export function preprocessWikilinks(markdown: string, publicFiles: readonly string[]): string {
+export function preprocessWikilinks(markdown: string, availableFiles: readonly string[]): string {
   const wikilinkRegex = /!\[\[([^\]]+)\]\]/g;
   return markdown.replace(wikilinkRegex, (match, content) => {
     const parts = content.split('|');
@@ -251,7 +255,7 @@ export function preprocessWikilinks(markdown: string, publicFiles: readonly stri
     }
 
     const normalizedFilename = filename.toLowerCase();
-    const resolvedPath = publicFiles.find((file) => {
+    const resolvedPath = availableFiles.find((file) => {
       const base = file.split('/').pop()?.toLowerCase();
       return base === normalizedFilename;
     });
@@ -267,7 +271,7 @@ export function preprocessWikilinks(markdown: string, publicFiles: readonly stri
 const defaultMarkdownRenderer = createMarkdownRenderer({
   getResponsiveImageAttributes,
   processMarkdown: async ({ markdown, plugin }) => {
-    const processedContent = await remark().use(plugin).use(html, { sanitize: false }).process(markdown);
+    const processedContent = await remark().use(gfm).use(plugin).use(html, { sanitize: false }).process(markdown);
     return processedContent.toString();
   },
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -2,6 +2,7 @@ import { remark } from "remark";
 import html from "remark-html";
 import type { Plugin } from "unified";
 import { getResponsiveImageAttributes, normalizeThumbnailSizes } from "./responsive-images";
+import { resolveMarkdownImagePaths } from "./local-images";
 
 export type MarkdownNode = {
   type: "root" | "paragraph" | "image" | "image-figure" | "element" | "text" | "html" | (string & {});
@@ -225,6 +226,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       getFigureProperties?: (largestWidth: number) => { class?: string; style?: string };
     }): Promise<string> {
       let preprocessed = publicFiles ? preprocessWikilinks(markdown, publicFiles) : markdown;
+      preprocessed = publicFiles ? resolveMarkdownImagePaths({ markdown: preprocessed, availableFiles: publicFiles }) : preprocessed;
       preprocessed = ensureImageBlockSeparation(preprocessed);
       return deps.processMarkdown({
         markdown: preprocessed,
@@ -273,4 +275,3 @@ const defaultMarkdownRenderer = createMarkdownRenderer({
 export const responsiveImagePlugin = defaultMarkdownRenderer.responsiveImagePlugin;
 export const applyResponsiveImages = defaultMarkdownRenderer.applyResponsiveImages;
 export const renderMarkdownContent = defaultMarkdownRenderer.renderMarkdownContent;
-

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -19,6 +19,7 @@ export const VaultDirectoryIndexSchema = z.object({
 export const VaultRootIndexSchema = VaultDirectoryIndexSchema.extend({
   directories: z.array(z.string()),
   publicFiles: z.array(z.string()),
+  assetFiles: z.array(z.string()).optional(),
   thumbnailSizes: z.array(z.number().int().positive()).optional(),
 });
 

--- a/src/lib/wordpress-blocks.test.ts
+++ b/src/lib/wordpress-blocks.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { serializeHtmlToWordPressBlocks } from "./wordpress-blocks";
+
+describe("serializeHtmlToWordPressBlocks", () => {
+  it("serializes top-level HTML into separate Gutenberg blocks", () => {
+    const html = [
+      "<h2>Overview</h2>",
+      "<p>Hello <strong>world</strong>.</p>",
+      '<figure class="wp-block-table is-style-stripes">',
+      "<table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>A</td></tr></tbody></table>",
+      "</figure>",
+    ].join("\n");
+
+    const result = serializeHtmlToWordPressBlocks(html);
+
+    expect(result).toContain("<!-- wp:heading -->\n<h2>Overview</h2>\n<!-- /wp:heading -->");
+    expect(result).toContain("<!-- wp:paragraph -->\n<p>Hello <strong>world</strong>.</p>\n<!-- /wp:paragraph -->");
+    expect(result).toContain('<!-- wp:table {"className":"is-style-stripes"} -->');
+    expect(result).toContain('<figure class="wp-block-table is-style-stripes">');
+    expect(result).toContain("<!-- /wp:table -->");
+    expect(result.indexOf("<!-- /wp:paragraph -->")).toBeLessThan(result.indexOf("<!-- wp:table"));
+  });
+
+  it("keeps ordered lists and image figures as their own blocks", () => {
+    const html = [
+      "<ol><li>One</li><li>Two</li></ol>",
+      '<figure class="wp-block-image"><img src="/image.png" alt="Image"></figure>',
+    ].join("\n");
+
+    const result = serializeHtmlToWordPressBlocks(html);
+
+    expect(result).toContain('<!-- wp:list {"ordered":true} -->');
+    expect(result).toContain("<ol><li>One</li><li>Two</li></ol>");
+    expect(result).toContain("<!-- wp:image -->");
+    expect(result).toContain('<figure class="wp-block-image"><img src="/image.png" alt="Image"></figure>');
+  });
+});

--- a/src/lib/wordpress-blocks.test.ts
+++ b/src/lib/wordpress-blocks.test.ts
@@ -34,4 +34,20 @@ describe("serializeHtmlToWordPressBlocks", () => {
     expect(result).toContain("<!-- wp:image -->");
     expect(result).toContain('<figure class="wp-block-image"><img src="/image.png" alt="Image"></figure>');
   });
+
+  it("does not let top-level void tags consume following blocks", () => {
+    const result = serializeHtmlToWordPressBlocks('<img src="/image.png"><p>After image</p>');
+
+    expect(result).toContain('<!-- wp:html -->\n<img src="/image.png">\n<!-- /wp:html -->');
+    expect(result).toContain("<!-- wp:paragraph -->\n<p>After image</p>\n<!-- /wp:paragraph -->");
+  });
+
+  it("reads table block classes only from the top-level figure", () => {
+    const result = serializeHtmlToWordPressBlocks(
+      '<figure><table><tbody><tr><td><span class="is-style-stripes">Nested</span></td></tr></tbody></table></figure>'
+    );
+
+    expect(result).toContain("<!-- wp:table -->");
+    expect(result).not.toContain('"className":"is-style-stripes"');
+  });
 });

--- a/src/lib/wordpress-blocks.ts
+++ b/src/lib/wordpress-blocks.ts
@@ -1,5 +1,22 @@
 type WordPressBlockAttributes = Record<string, string | number | boolean>;
 
+const VOID_HTML_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
 function serializeAttributes(attributes: WordPressBlockAttributes): string {
   const entries = Object.entries(attributes);
   if (entries.length === 0) {
@@ -27,9 +44,19 @@ function getOpeningTagName(html: string): string | null {
   return match ? match[1].toLowerCase() : null;
 }
 
+function getOpeningTag(html: string): string | null {
+  const match = /^<\s*[a-zA-Z][\w:-]*\b[^>]*>/.exec(html.trimStart());
+  return match ? match[0] : null;
+}
+
 function getAttributeValue({ html, name }: { html: string; name: string }): string | null {
+  const openingTag = getOpeningTag(html);
+  if (!openingTag) {
+    return null;
+  }
+
   const pattern = new RegExp(`\\b${name}\\s*=\\s*(["'])(.*?)\\1`, "i");
-  const match = pattern.exec(html);
+  const match = pattern.exec(openingTag);
   return match ? match[2] : null;
 }
 
@@ -48,6 +75,15 @@ function getBlockClassName(html: string, baseClassName: string): string | null {
 }
 
 function findElementEnd({ html, startIndex, tagName }: { html: string; startIndex: number; tagName: string }): number {
+  const openingTagMatch = /^<\s*[a-zA-Z][\w:-]*\b[^>]*>/.exec(html.slice(startIndex));
+  if (!openingTagMatch) {
+    return startIndex + 1;
+  }
+
+  if (VOID_HTML_TAGS.has(tagName) || /\/\s*>$/.test(openingTagMatch[0])) {
+    return startIndex + openingTagMatch[0].length;
+  }
+
   const tagPattern = new RegExp(`<\\/?${tagName}\\b[^>]*>`, "gi");
   tagPattern.lastIndex = startIndex;
 

--- a/src/lib/wordpress-blocks.ts
+++ b/src/lib/wordpress-blocks.ts
@@ -1,0 +1,177 @@
+type WordPressBlockAttributes = Record<string, string | number | boolean>;
+
+function serializeAttributes(attributes: WordPressBlockAttributes): string {
+  const entries = Object.entries(attributes);
+  if (entries.length === 0) {
+    return "";
+  }
+
+  return ` ${JSON.stringify(attributes)}`;
+}
+
+function wrapWordPressBlock({
+  blockName,
+  html,
+  attributes = {},
+}: {
+  blockName: string;
+  html: string;
+  attributes?: WordPressBlockAttributes;
+}): string {
+  const serializedAttributes = serializeAttributes(attributes);
+  return `<!-- wp:${blockName}${serializedAttributes} -->\n${html}\n<!-- /wp:${blockName} -->`;
+}
+
+function getOpeningTagName(html: string): string | null {
+  const match = /^<\s*([a-zA-Z][\w:-]*)\b/.exec(html.trimStart());
+  return match ? match[1].toLowerCase() : null;
+}
+
+function getAttributeValue({ html, name }: { html: string; name: string }): string | null {
+  const pattern = new RegExp(`\\b${name}\\s*=\\s*(["'])(.*?)\\1`, "i");
+  const match = pattern.exec(html);
+  return match ? match[2] : null;
+}
+
+function getBlockClassName(html: string, baseClassName: string): string | null {
+  const classValue = getAttributeValue({ html, name: "class" });
+  if (!classValue) {
+    return null;
+  }
+
+  const blockClasses = classValue
+    .split(/\s+/)
+    .map((className) => className.trim())
+    .filter((className) => className.length > 0 && className !== baseClassName);
+
+  return blockClasses.length > 0 ? blockClasses.join(" ") : null;
+}
+
+function findElementEnd({ html, startIndex, tagName }: { html: string; startIndex: number; tagName: string }): number {
+  const tagPattern = new RegExp(`<\\/?${tagName}\\b[^>]*>`, "gi");
+  tagPattern.lastIndex = startIndex;
+
+  let depth = 0;
+  let match: RegExpExecArray | null;
+  while ((match = tagPattern.exec(html)) !== null) {
+    const tag = match[0];
+    const isClosingTag = /^<\s*\//.test(tag);
+    const isSelfClosingTag = /\/\s*>$/.test(tag);
+
+    if (isClosingTag) {
+      depth -= 1;
+      if (depth === 0) {
+        return tagPattern.lastIndex;
+      }
+    } else if (!isSelfClosingTag) {
+      depth += 1;
+    }
+  }
+
+  return html.length;
+}
+
+function splitTopLevelHtml(html: string): string[] {
+  const blocks: string[] = [];
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const nextTagIndex = html.indexOf("<", cursor);
+    if (nextTagIndex === -1) {
+      const remainingText = html.slice(cursor).trim();
+      if (remainingText.length > 0) {
+        blocks.push(remainingText);
+      }
+      break;
+    }
+
+    const textBeforeTag = html.slice(cursor, nextTagIndex).trim();
+    if (textBeforeTag.length > 0) {
+      blocks.push(textBeforeTag);
+    }
+
+    if (html.startsWith("<!--", nextTagIndex)) {
+      const commentEndIndex = html.indexOf("-->", nextTagIndex + 4);
+      const endIndex = commentEndIndex === -1 ? html.length : commentEndIndex + 3;
+      blocks.push(html.slice(nextTagIndex, endIndex).trim());
+      cursor = endIndex;
+      continue;
+    }
+
+    const tagMatch = /^<\s*([a-zA-Z][\w:-]*)\b[^>]*>/.exec(html.slice(nextTagIndex));
+    if (!tagMatch) {
+      const nextCharacterIndex = nextTagIndex + 1;
+      blocks.push(html.slice(nextTagIndex, nextCharacterIndex));
+      cursor = nextCharacterIndex;
+      continue;
+    }
+
+    const tagName = tagMatch[1].toLowerCase();
+    const endIndex = findElementEnd({ html, startIndex: nextTagIndex, tagName });
+    blocks.push(html.slice(nextTagIndex, endIndex).trim());
+    cursor = endIndex;
+  }
+
+  return blocks.filter((block) => block.length > 0);
+}
+
+function serializeTableBlock(html: string): string {
+  const className = getBlockClassName(html, "wp-block-table");
+  const attributes: WordPressBlockAttributes = className ? { className } : {};
+  return wrapWordPressBlock({ blockName: "table", html, attributes });
+}
+
+function serializeHeadingBlock({ html, tagName }: { html: string; tagName: string }): string {
+  const level = Number.parseInt(tagName.replace("h", ""), 10);
+  const attributes: WordPressBlockAttributes = level === 2 ? {} : { level };
+  return wrapWordPressBlock({ blockName: "heading", html, attributes });
+}
+
+function serializeListBlock({ html, tagName }: { html: string; tagName: string }): string {
+  const attributes: WordPressBlockAttributes = tagName === "ol" ? { ordered: true } : {};
+  return wrapWordPressBlock({ blockName: "list", html, attributes });
+}
+
+function serializeKnownBlock(html: string): string {
+  const tagName = getOpeningTagName(html);
+
+  if (!tagName) {
+    return wrapWordPressBlock({ blockName: "html", html });
+  }
+
+  if (tagName === "figure" && /<table\b/i.test(html)) {
+    return serializeTableBlock(html);
+  }
+
+  if (tagName === "figure" && /<img\b/i.test(html)) {
+    return wrapWordPressBlock({ blockName: "image", html });
+  }
+
+  if (tagName === "p") {
+    return wrapWordPressBlock({ blockName: "paragraph", html });
+  }
+
+  if (/^h[1-6]$/.test(tagName)) {
+    return serializeHeadingBlock({ html, tagName });
+  }
+
+  if (tagName === "ul" || tagName === "ol") {
+    return serializeListBlock({ html, tagName });
+  }
+
+  if (tagName === "blockquote") {
+    return wrapWordPressBlock({ blockName: "quote", html });
+  }
+
+  if (tagName === "pre") {
+    return wrapWordPressBlock({ blockName: "code", html });
+  }
+
+  return wrapWordPressBlock({ blockName: "html", html });
+}
+
+export function serializeHtmlToWordPressBlocks(html: string): string {
+  return splitTopLevelHtml(html)
+    .map(serializeKnownBlock)
+    .join("\n\n");
+}


### PR DESCRIPTION
## Summary
- Fix local/encoded image resolution so Markdown image references map to responsive thumbnail URLs consistently.
- Wrap rendered Markdown tables in WordPress table figures with striped styling support.
- Serialize WordPress publish payloads as discrete Gutenberg blocks instead of one raw HTML blob, preserving table blocks as valid `wp:table` blocks.
- Add focused tests for image path handling, Markdown rendering, table publishing, and Gutenberg block serialization.

## Why
WordPress REST updates were receiving rendered HTML without Gutenberg block delimiters, so the editor/theme treated pushed content as a single HTML block. That prevented table styles from applying correctly on posts like `vpn-comparison-guide`.

## Validation
- `npm run type-check`
- `npm run test`
- Republished `vpn-comparison-guide` and verified via WordPress REST editor content: 34 Gutenberg blocks, 2 table blocks, 0 HTML fallback blocks, striped table style present, no horizontal-rule/separator blocks.
