### PR TITLE
[codex] Add vault agent rules and WordPress block fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ next-env.d.ts
 
 # app
 registry.json
+root.json
+**/index.json
 
 # cloudflare
 .wrangler/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - Always run `npm run type-check` after making changes to verify basic syntax errors.
 - **Strictly avoid using `any` type** anywhere in the codebase. Always write proper TypeScript types, schemas, or interfaces for safety and clarity.
 
+# Generated Content Indexes
+- Treat vault `root.json` files and generated `index.json` files as build artifacts. Do not edit them during article/content edits.
+- Article agents should update source Markdown and source assets only. Regenerate indexes with the existing sync/deploy tooling when explicitly requested.
+- If generated index files appear in a diff after article edits, leave them unstaged and revert only those generated artifacts after confirming they were not intentionally requested.
 
 # Architecture
 - Keep main entrance files clean as orchestrators. Move feature logic, parsing, file scanning, rendering transforms, and other reusable behavior into focused modules instead of letting scripts or page files grow bloated.

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -13,6 +13,7 @@ import { exists } from './lib/files';
 import { generateIndices } from './lib/indices';
 import { generateSitemaps } from './lib/sitemaps';
 import { pushToWordPress, pullFromWordPress } from './lib/wordpress';
+import { ensureVaultAgentRules } from './lib/agent-rules';
 
 type CommandResult = {
   status: number | null;
@@ -398,6 +399,8 @@ async function syncContent({
   isDryRun: boolean;
 }) {
   const thumbnailSizes = normalizeThumbnailSizes(site.thumbnailSizes || registry.thumbnailSizes);
+  await ensureVaultAgentRules({ vaultPath: site.vaultPath, dryRun: isDryRun });
+
   const { rootContentIndex, allIndices } = await generateIndices({
     vaultPath: site.vaultPath,
     thumbnailSizes,

--- a/scripts/lib/agent-rules.test.ts
+++ b/scripts/lib/agent-rules.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { createAgentRulesWriter } from './agent-rules';
+
+describe('createAgentRulesWriter', () => {
+  it('creates vault AGENTS.md rules when missing', async () => {
+    const writes: Record<string, string> = {};
+    const logger = { log: vi.fn() };
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => false),
+      readFile: vi.fn(async () => ''),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      logger,
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: false });
+
+    expect(writes['vault/AGENTS.md']).toContain('<!-- BEGIN:notopress-vault-agent-rules -->');
+    expect(writes['vault/AGENTS.md']).toContain('This is a Notopress vault');
+    expect(writes['vault/AGENTS.md']).toContain('directory-level `index.json`');
+    expect(writes['vault/AGENTS.md'].endsWith('\n')).toBe(true);
+  });
+
+  it('replaces the managed block while preserving user notes', async () => {
+    const writes: Record<string, string> = {};
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => true),
+      readFile: vi.fn(async () =>
+        [
+          '# Personal notes',
+          '',
+          '<!-- BEGIN:notopress-vault-agent-rules -->',
+          'old rules',
+          '<!-- END:notopress-vault-agent-rules -->',
+          '',
+          'Keep this custom note.',
+          '',
+        ].join('\n')
+      ),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      logger: { log: vi.fn() },
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: false });
+
+    expect(writes['vault/AGENTS.md']).toContain('# Personal notes');
+    expect(writes['vault/AGENTS.md']).toContain('Keep this custom note.');
+    expect(writes['vault/AGENTS.md']).not.toContain('old rules');
+  });
+
+  it('appends the managed block to an existing user-authored AGENTS.md', async () => {
+    const writes: Record<string, string> = {};
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => true),
+      readFile: vi.fn(async () => '# User rules\n\nKeep article titles short.\n'),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      logger: { log: vi.fn() },
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: false });
+
+    expect(writes['vault/AGENTS.md'].startsWith('# User rules\n\nKeep article titles short.')).toBe(true);
+    expect(writes['vault/AGENTS.md']).toContain('<!-- BEGIN:notopress-vault-agent-rules -->');
+    expect(writes['vault/AGENTS.md']).toContain('<!-- END:notopress-vault-agent-rules -->');
+  });
+
+  it('does not write during dry run', async () => {
+    const writeFile = vi.fn(async () => undefined);
+    const logger = { log: vi.fn() };
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => false),
+      readFile: vi.fn(async () => ''),
+      writeFile,
+      joinPath: path.posix.join,
+      logger,
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: true });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith('[DRY RUN] Would update vault AGENTS.md at: vault/AGENTS.md');
+  });
+
+  it('does not rewrite an up-to-date rules file', async () => {
+    const existingContent = [
+      '<!-- BEGIN:notopress-vault-agent-rules -->',
+      '# This is a Notopress vault',
+      '',
+      'This vault is synced by Notopress. Edit source Markdown files and source assets, but do not manually edit generated files such as `root.json`, directory-level `index.json`, or generated thumbnails. Regenerate them with the Notopress sync tooling when needed.',
+      '',
+      'Keep article metadata consistent with the surrounding Markdown files. Preserve existing frontmatter fields unless the edit explicitly requires changing them.',
+      '<!-- END:notopress-vault-agent-rules -->',
+      '',
+    ].join('\n');
+    const writeFile = vi.fn(async () => undefined);
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => true),
+      readFile: vi.fn(async () => existingContent),
+      writeFile,
+      joinPath: path.posix.join,
+      logger: { log: vi.fn() },
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: false });
+
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/lib/agent-rules.test.ts
+++ b/scripts/lib/agent-rules.test.ts
@@ -21,6 +21,7 @@ describe('createAgentRulesWriter', () => {
     expect(writes['vault/AGENTS.md']).toContain('<!-- BEGIN:notopress-vault-agent-rules -->');
     expect(writes['vault/AGENTS.md']).toContain('This is a Notopress vault');
     expect(writes['vault/AGENTS.md']).toContain('directory-level `index.json`');
+    expect(writes['vault/AGENTS.md']).toContain('Plain paragraphs are treated as normal article text, not captions.');
     expect(writes['vault/AGENTS.md'].endsWith('\n')).toBe(true);
   });
 
@@ -98,6 +99,8 @@ describe('createAgentRulesWriter', () => {
       'This vault is synced by Notopress. Edit source Markdown files and source assets, but do not manually edit generated files such as `root.json`, directory-level `index.json`, or generated thumbnails. Regenerate them with the Notopress sync tooling when needed.',
       '',
       'Keep article metadata consistent with the surrounding Markdown files. Preserve existing frontmatter fields unless the edit explicitly requires changing them.',
+      '',
+      'For captions, use a single italic paragraph immediately after the media or table. For table captions, place the caption directly after the Markdown table, for example: `*Feature comparison table.*`. Plain paragraphs are treated as normal article text, not captions.',
       '<!-- END:notopress-vault-agent-rules -->',
       '',
     ].join('\n');

--- a/scripts/lib/agent-rules.test.ts
+++ b/scripts/lib/agent-rules.test.ts
@@ -74,6 +74,91 @@ describe('createAgentRulesWriter', () => {
     expect(writes['vault/AGENTS.md']).toContain('<!-- END:notopress-vault-agent-rules -->');
   });
 
+  it('repairs an orphaned begin marker without dropping user notes', async () => {
+    const writes: Record<string, string> = {};
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => true),
+      readFile: vi.fn(async () =>
+        [
+          '# User rules',
+          '',
+          '<!-- BEGIN:notopress-vault-agent-rules -->',
+          'Keep this custom note.',
+          '',
+        ].join('\n')
+      ),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      logger: { log: vi.fn() },
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: false });
+
+    expect(writes['vault/AGENTS.md']).toContain('# User rules');
+    expect(writes['vault/AGENTS.md']).toContain('Keep this custom note.');
+    expect(writes['vault/AGENTS.md'].match(/<!-- BEGIN:notopress-vault-agent-rules -->/g)).toHaveLength(1);
+    expect(writes['vault/AGENTS.md']).toContain('<!-- END:notopress-vault-agent-rules -->');
+  });
+
+  it('repairs an orphaned end marker without dropping user notes', async () => {
+    const writes: Record<string, string> = {};
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => true),
+      readFile: vi.fn(async () =>
+        [
+          '# User rules',
+          '',
+          'Keep this custom note.',
+          '<!-- END:notopress-vault-agent-rules -->',
+          '',
+        ].join('\n')
+      ),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      logger: { log: vi.fn() },
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: false });
+
+    expect(writes['vault/AGENTS.md']).toContain('# User rules');
+    expect(writes['vault/AGENTS.md']).toContain('Keep this custom note.');
+    expect(writes['vault/AGENTS.md']).toContain('<!-- BEGIN:notopress-vault-agent-rules -->');
+    expect(writes['vault/AGENTS.md'].match(/<!-- END:notopress-vault-agent-rules -->/g)).toHaveLength(1);
+  });
+
+  it('repairs reversed markers without dropping user notes', async () => {
+    const writes: Record<string, string> = {};
+    const writer = createAgentRulesWriter({
+      exists: vi.fn(async () => true),
+      readFile: vi.fn(async () =>
+        [
+          '# User rules',
+          '',
+          '<!-- END:notopress-vault-agent-rules -->',
+          'Keep this custom note.',
+          '<!-- BEGIN:notopress-vault-agent-rules -->',
+          '',
+        ].join('\n')
+      ),
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        writes[filePath] = content;
+      }),
+      joinPath: path.posix.join,
+      logger: { log: vi.fn() },
+    });
+
+    await writer.ensureVaultAgentRules({ vaultPath: 'vault', dryRun: false });
+
+    expect(writes['vault/AGENTS.md']).toContain('# User rules');
+    expect(writes['vault/AGENTS.md']).toContain('Keep this custom note.');
+    expect(writes['vault/AGENTS.md'].match(/<!-- BEGIN:notopress-vault-agent-rules -->/g)).toHaveLength(1);
+    expect(writes['vault/AGENTS.md'].match(/<!-- END:notopress-vault-agent-rules -->/g)).toHaveLength(1);
+  });
+
   it('does not write during dry run', async () => {
     const writeFile = vi.fn(async () => undefined);
     const logger = { log: vi.fn() };

--- a/scripts/lib/agent-rules.ts
+++ b/scripts/lib/agent-rules.ts
@@ -1,0 +1,79 @@
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { exists } from './files';
+
+type Logger = Pick<typeof console, 'log'>;
+
+export type AgentRulesDeps = {
+  exists: (path: string) => Promise<boolean>;
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
+  writeFile: (path: string, content: string) => Promise<void>;
+  joinPath: (...paths: string[]) => string;
+  logger: Logger;
+};
+
+const AGENTS_FILENAME = 'AGENTS.md';
+const BEGIN_MARKER = '<!-- BEGIN:notopress-vault-agent-rules -->';
+const END_MARKER = '<!-- END:notopress-vault-agent-rules -->';
+
+const VAULT_AGENT_RULES = `${BEGIN_MARKER}
+# This is a Notopress vault
+
+This vault is synced by Notopress. Edit source Markdown files and source assets, but do not manually edit generated files such as \`root.json\`, directory-level \`index.json\`, or generated thumbnails. Regenerate them with the Notopress sync tooling when needed.
+
+Keep article metadata consistent with the surrounding Markdown files. Preserve existing frontmatter fields unless the edit explicitly requires changing them.
+${END_MARKER}`;
+
+function ensureTrailingNewline(content: string): string {
+  return content.endsWith('\n') ? content : `${content}\n`;
+}
+
+function replaceManagedBlock({ content, block }: { content: string; block: string }): string {
+  const startIndex = content.indexOf(BEGIN_MARKER);
+  const endIndex = content.indexOf(END_MARKER);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    const trimmedContent = content.trimEnd();
+    return trimmedContent ? `${trimmedContent}\n\n${block}\n` : `${block}\n`;
+  }
+
+  const before = content.slice(0, startIndex).trimEnd();
+  const after = content.slice(endIndex + END_MARKER.length).trimStart();
+  const prefix = before ? `${before}\n\n` : '';
+  const suffix = after ? `\n\n${after}` : '';
+
+  return `${prefix}${block}${suffix}`;
+}
+
+export function createAgentRulesWriter(deps: AgentRulesDeps) {
+  return {
+    async ensureVaultAgentRules({ vaultPath, dryRun }: { vaultPath: string; dryRun: boolean }): Promise<void> {
+      const agentsPath = deps.joinPath(vaultPath, AGENTS_FILENAME);
+      const existingContent = (await deps.exists(agentsPath)) ? await deps.readFile(agentsPath, 'utf-8') : '';
+      const nextContent = ensureTrailingNewline(replaceManagedBlock({ content: existingContent, block: VAULT_AGENT_RULES }));
+
+      if (nextContent === ensureTrailingNewline(existingContent)) {
+        deps.logger.log(`✅ ${AGENTS_FILENAME} agent rules are up to date.`);
+        return;
+      }
+
+      if (dryRun) {
+        deps.logger.log(`[DRY RUN] Would update vault ${AGENTS_FILENAME} at: ${agentsPath}`);
+        return;
+      }
+
+      await deps.writeFile(agentsPath, nextContent);
+      deps.logger.log(`✨ Updated vault ${AGENTS_FILENAME} agent rules.`);
+    },
+  };
+}
+
+const defaultAgentRulesWriter = createAgentRulesWriter({
+  exists,
+  readFile,
+  writeFile,
+  joinPath: path.join,
+  logger: console,
+});
+
+export const ensureVaultAgentRules = defaultAgentRulesWriter.ensureVaultAgentRules;

--- a/scripts/lib/agent-rules.ts
+++ b/scripts/lib/agent-rules.ts
@@ -30,13 +30,36 @@ function ensureTrailingNewline(content: string): string {
   return content.endsWith('\n') ? content : `${content}\n`;
 }
 
+function appendManagedBlock({ content, block }: { content: string; block: string }): string {
+  const trimmedContent = content.trimEnd();
+  return trimmedContent ? `${trimmedContent}\n\n${block}\n` : `${block}\n`;
+}
+
+function removeMarker(content: string, marker: string): string {
+  return content.replace(marker, '').replace(/\n{3,}/g, '\n\n');
+}
+
 function replaceManagedBlock({ content, block }: { content: string; block: string }): string {
   const startIndex = content.indexOf(BEGIN_MARKER);
   const endIndex = content.indexOf(END_MARKER);
 
-  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-    const trimmedContent = content.trimEnd();
-    return trimmedContent ? `${trimmedContent}\n\n${block}\n` : `${block}\n`;
+  if (startIndex === -1 && endIndex === -1) {
+    return appendManagedBlock({ content, block });
+  }
+
+  if (startIndex === -1) {
+    return appendManagedBlock({ content: removeMarker(content, END_MARKER), block });
+  }
+
+  if (endIndex === -1) {
+    return appendManagedBlock({ content: removeMarker(content, BEGIN_MARKER), block });
+  }
+
+  if (endIndex < startIndex) {
+    return appendManagedBlock({
+      content: removeMarker(removeMarker(content, BEGIN_MARKER), END_MARKER),
+      block,
+    });
   }
 
   const before = content.slice(0, startIndex).trimEnd();

--- a/scripts/lib/agent-rules.ts
+++ b/scripts/lib/agent-rules.ts
@@ -22,6 +22,8 @@ const VAULT_AGENT_RULES = `${BEGIN_MARKER}
 This vault is synced by Notopress. Edit source Markdown files and source assets, but do not manually edit generated files such as \`root.json\`, directory-level \`index.json\`, or generated thumbnails. Regenerate them with the Notopress sync tooling when needed.
 
 Keep article metadata consistent with the surrounding Markdown files. Preserve existing frontmatter fields unless the edit explicitly requires changing them.
+
+For captions, use a single italic paragraph immediately after the media or table. For table captions, place the caption directly after the Markdown table, for example: \`*Feature comparison table.*\`. Plain paragraphs are treated as normal article text, not captions.
 ${END_MARKER}`;
 
 function ensureTrailingNewline(content: string): string {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -299,7 +299,7 @@ describe('WordPress Deployment Library', () => {
       const body = JSON.parse(postCall![1].body);
       expect(body.content).toContain('<!-- wp:table {"className":"is-style-stripes"} -->');
       expect(body.content).toContain('<figure class="wp-block-table is-style-stripes">');
-      expect(body.content).toContain('<table>');
+      expect(body.content).toContain('<table class="has-fixed-layout">');
       expect(body.content).toContain('</table>\n</figure>');
       expect(body.content).toContain('<!-- /wp:table -->');
     });

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -93,6 +93,44 @@ describe("createMarkdownRenderer", () => {
     expect(html).toContain('<figure class="custom-table" style="overflow-x: auto;">');
   });
 
+  it("consumes adjacent italicized paragraph as a table figcaption", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: [
+        "| Feature | Basic | Pro |",
+        "| --- | --- | --- |",
+        "| Export | Yes | Yes |",
+        "",
+        "*Feature comparison table.*",
+      ].join("\n"),
+      thumbnailSizes: [320],
+      getTableFigureProperties: () => ({ class: 'wp-block-table is-style-stripes' }),
+    });
+
+    expect(html).toContain('<figure class="wp-block-table is-style-stripes">');
+    expect(html).toContain('<figcaption>Feature comparison table.</figcaption>');
+    expect(html).not.toContain('<p><em>Feature comparison table.</em></p>');
+  });
+
+  it("leaves preceding italicized paragraphs as normal text before tables", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: [
+        "*Feature comparison table.*",
+        "",
+        "| Feature | Basic | Pro |",
+        "| --- | --- | --- |",
+        "| Export | Yes | Yes |",
+      ].join("\n"),
+      thumbnailSizes: [320],
+      getTableFigureProperties: () => ({ class: 'wp-block-table is-style-stripes' }),
+    });
+
+    expect(html).toContain('<figure class="wp-block-table is-style-stripes">');
+    expect(html).toContain('<p><em>Feature comparison table.</em></p>');
+    expect(html).not.toContain('<figcaption>Feature comparison table.</figcaption>');
+  });
+
   it("does not wrap tables already inside figures with long attributes", async () => {
     const { wrapTablesInFigures } = await import("./markdown");
     const figureClass = "wp-block-table is-style-stripes has-fixed-layout alignwide custom-long-class-name";

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -60,7 +60,7 @@ export function wrapTablesInFigures(
   htmlContent: string,
   getFigureProperties?: () => FigureProperties,
 ): string {
-  return htmlContent.replace(/<table(?:\s[^>]*)?>[\s\S]*?<\/table>/g, (tableHtml, offset, fullHtml) => {
+  const wrappedTables = htmlContent.replace(/<table(?:\s[^>]*)?>[\s\S]*?<\/table>/g, (tableHtml, offset, fullHtml) => {
     const precedingHtml = fullHtml.slice(0, offset);
     const lastFigureOpenIndex = precedingHtml.search(/<figure\b[^>]*>\s*$/i);
     const lastFigureCloseIndex = precedingHtml.lastIndexOf("</figure>");
@@ -72,6 +72,13 @@ export function wrapTablesInFigures(
     const attributes = serializeFigureProperties(properties);
     return `<figure${attributes}>\n${tableHtml}\n</figure>`;
   });
+
+  return wrappedTables.replace(
+    /(<figure(?:\s[^>]*)?>\s*<table(?:\s[^>]*)?>[\s\S]*?<\/table>\s*)<\/figure>\s*<p><em>([\s\S]*?)<\/em><\/p>/g,
+    (_match: string, figureWithTable: string, captionHtml: string) => {
+      return `${figureWithTable}<figcaption>${captionHtml}</figcaption>\n</figure>`;
+    }
+  );
 }
 
 export function createMarkdownRenderer(deps: MarkdownRendererDeps) {

--- a/src/lib/wordpress-blocks.test.ts
+++ b/src/lib/wordpress-blocks.test.ts
@@ -31,8 +31,62 @@ describe("serializeHtmlToWordPressBlocks", () => {
 
     expect(result).toContain('<!-- wp:list {"ordered":true} -->');
     expect(result).toContain("<ol><li>One</li><li>Two</li></ol>");
-    expect(result).toContain("<!-- wp:image -->");
-    expect(result).toContain('<figure class="wp-block-image"><img src="/image.png" alt="Image"></figure>');
+    expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
+    expect(result).toContain('<figure class="size-large wp-block-image"><img src="/image.png" alt="Image"></figure>');
+  });
+
+  it("normalizes image blocks to Gutenberg-compatible markup", () => {
+    const result = serializeHtmlToWordPressBlocks(
+      '<figure class="image-figure" style="height: auto !important;"><img src="/image.png" style="max-width: 100%;" srcset="/image-320.png 320w" sizes="100vw" loading="lazy" decoding="async" alt="Image"><figcaption>Image caption</figcaption></figure>'
+    );
+
+    expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"image-figure"} -->');
+    expect(result).toContain('<figure class="size-large wp-block-image image-figure">');
+    expect(result).toContain('<img src="/image.png" alt="Image">');
+    expect(result).toContain('<figcaption class="wp-element-caption">Image caption</figcaption>');
+    expect(result).not.toContain('style="max-width: 100%;"');
+    expect(result).not.toContain('style="height: auto !important;"');
+    expect(result).not.toContain("srcset=");
+    expect(result).not.toContain("sizes=");
+    expect(result).not.toContain("loading=");
+    expect(result).not.toContain("decoding=");
+  });
+
+  it("normalizes quote blocks to Gutenberg-compatible markup", () => {
+    const result = serializeHtmlToWordPressBlocks("<blockquote><p>Quote text here.</p></blockquote>");
+
+    expect(result).toContain("<!-- wp:quote -->");
+    expect(result).toContain('<blockquote class="wp-block-quote"><p>Quote text here.</p></blockquote>');
+  });
+
+  it("keeps extra quote classes in block attributes", () => {
+    const result = serializeHtmlToWordPressBlocks('<blockquote class="is-style-large"><p>Quote text here.</p></blockquote>');
+
+    expect(result).toContain('<!-- wp:quote {"className":"is-style-large"} -->');
+    expect(result).toContain('<blockquote class="wp-block-quote is-style-large"><p>Quote text here.</p></blockquote>');
+  });
+
+  it("normalizes table captions to Gutenberg-compatible markup", () => {
+    const result = serializeHtmlToWordPressBlocks(
+      '<figure class="wp-block-table is-style-stripes"><table><thead><tr><th align="left">Name</th></tr></thead><tbody><tr><td align="left">A</td></tr></tbody></table><figcaption>Feature comparison table.</figcaption></figure>'
+    );
+
+    expect(result).toContain('<!-- wp:table {"className":"is-style-stripes"} -->');
+    expect(result).toContain('<table class="has-fixed-layout">');
+    expect(result).not.toContain(' align="left"');
+    expect(result).toContain('<figcaption class="wp-element-caption">Feature comparison table.</figcaption>');
+  });
+
+  it("does not duplicate WordPress block classes during normalization", () => {
+    const result = serializeHtmlToWordPressBlocks(
+      '<figure class="wp-block-image"><img src="/image.png" alt="Image"><figcaption class="wp-element-caption">Image caption</figcaption></figure>'
+    );
+
+    expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
+    expect(result).toContain('<figure class="size-large wp-block-image">');
+    expect(result).toContain('<figcaption class="wp-element-caption">Image caption</figcaption>');
+    expect(result).not.toContain("wp-block-image wp-block-image");
+    expect(result).not.toContain("wp-element-caption wp-element-caption");
   });
 
   it("does not let top-level void tags consume following blocks", () => {

--- a/src/lib/wordpress-blocks.test.ts
+++ b/src/lib/wordpress-blocks.test.ts
@@ -42,14 +42,11 @@ describe("serializeHtmlToWordPressBlocks", () => {
 
     expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"image-figure"} -->');
     expect(result).toContain('<figure class="size-large wp-block-image image-figure">');
-    expect(result).toContain('<img src="/image.png" alt="Image">');
+    expect(result).toContain(
+      '<img src="/image.png" style="max-width: 100%;" srcset="/image-320.png 320w" sizes="100vw" loading="lazy" decoding="async" alt="Image">'
+    );
     expect(result).toContain('<figcaption class="wp-element-caption">Image caption</figcaption>');
-    expect(result).not.toContain('style="max-width: 100%;"');
     expect(result).not.toContain('style="height: auto !important;"');
-    expect(result).not.toContain("srcset=");
-    expect(result).not.toContain("sizes=");
-    expect(result).not.toContain("loading=");
-    expect(result).not.toContain("decoding=");
   });
 
   it("normalizes quote blocks to Gutenberg-compatible markup", () => {

--- a/src/lib/wordpress-blocks.ts
+++ b/src/lib/wordpress-blocks.ts
@@ -1,4 +1,14 @@
 type WordPressBlockAttributes = Record<string, string | number | boolean>;
+type WordPressBlockName = "code" | "heading" | "html" | "image" | "list" | "paragraph" | "quote" | "table";
+type RootElementBlock = {
+  blockName: WordPressBlockName;
+  html: string;
+  rootTagName: string;
+  baseClassName: string;
+  captionClassName?: string;
+  stripRootStyles?: boolean;
+  stripImageStyles?: boolean;
+};
 
 const VOID_HTML_TAGS = new Set([
   "area",
@@ -31,7 +41,7 @@ function wrapWordPressBlock({
   html,
   attributes = {},
 }: {
-  blockName: string;
+  blockName: WordPressBlockName;
   html: string;
   attributes?: WordPressBlockAttributes;
 }): string {
@@ -60,18 +70,153 @@ function getAttributeValue({ html, name }: { html: string; name: string }): stri
   return match ? match[2] : null;
 }
 
-function getBlockClassName(html: string, baseClassName: string): string | null {
+function getBlockClassName({
+  html,
+  baseClassName,
+  ignoredClassNames = [],
+}: {
+  html: string;
+  baseClassName: string;
+  ignoredClassNames?: readonly string[];
+}): string | null {
   const classValue = getAttributeValue({ html, name: "class" });
   if (!classValue) {
     return null;
   }
 
+  const ignoredClassNameSet = new Set([baseClassName, ...ignoredClassNames]);
   const blockClasses = classValue
     .split(/\s+/)
     .map((className) => className.trim())
-    .filter((className) => className.length > 0 && className !== baseClassName);
+    .filter((className) => className.length > 0 && !ignoredClassNameSet.has(className));
 
   return blockClasses.length > 0 ? blockClasses.join(" ") : null;
+}
+
+const WORDPRESS_CAPTION_CLASS = "wp-element-caption";
+const WORDPRESS_IMAGE_CLASS = "wp-block-image";
+const WORDPRESS_QUOTE_CLASS = "wp-block-quote";
+const WORDPRESS_TABLE_CLASS = "wp-block-table";
+
+function mergeClassNames({ existingClassName, classNames }: { existingClassName: string | null; classNames: readonly string[] }): string {
+  const allClassNames = [
+    ...classNames,
+    ...(existingClassName || "").split(/\s+/),
+  ]
+    .map((className) => className.trim())
+    .filter((className) => className.length > 0);
+
+  return [...new Set(allClassNames)].join(" ");
+}
+
+function addClassToOpeningTag({ html, tagName, className }: { html: string; tagName: string; className: string }): string {
+  const pattern = new RegExp(`^<${tagName}\\b([^>]*)>`, "i");
+  const match = pattern.exec(html.trimStart());
+  if (!match) {
+    return html;
+  }
+
+  const openingTag = match[0];
+  const existingClassName = getAttributeValue({ html, name: "class" });
+  const mergedClassName = mergeClassNames({ existingClassName, classNames: [className] });
+  const nextOpeningTag = existingClassName
+    ? openingTag.replace(/\bclass\s*=\s*(["']).*?\1/i, `class="${mergedClassName}"`)
+    : openingTag.replace(new RegExp(`^<${tagName}\\b`, "i"), `<${tagName} class="${mergedClassName}"`);
+
+  return html.replace(openingTag, nextOpeningTag);
+}
+
+function addClassToElements({ html, tagName, className }: { html: string; tagName: string; className: string }): string {
+  const pattern = new RegExp(`<${tagName}\\b([^>]*)>`, "gi");
+  return html.replace(pattern, (openingTag: string) => {
+    const classMatch = /\bclass\s*=\s*(["'])(.*?)\1/i.exec(openingTag);
+    const mergedClassName = mergeClassNames({ existingClassName: classMatch ? classMatch[2] : null, classNames: [className] });
+    if (classMatch) {
+      return openingTag.replace(/\bclass\s*=\s*(["']).*?\1/i, `class="${mergedClassName}"`);
+    }
+
+    return openingTag.replace(new RegExp(`^<${tagName}\\b`, "i"), `<${tagName} class="${mergedClassName}"`);
+  });
+}
+
+function stripAttributeFromElements({
+  html,
+  tagNames,
+  attributeName,
+}: {
+  html: string;
+  tagNames: readonly string[];
+  attributeName: string;
+}): string {
+  const tagPattern = tagNames.join("|");
+  const elementPattern = new RegExp(`<(${tagPattern})\\b[^>]*>`, "gi");
+  const attributePattern = new RegExp(`\\s${attributeName}\\s*=\\s*(["']).*?\\1`, "i");
+
+  return html.replace(elementPattern, (openingTag: string) => {
+    return openingTag.replace(attributePattern, "");
+  });
+}
+
+function normalizeTableHtml(html: string): string {
+  return stripAttributeFromElements({
+    html: addClassToElements({ html, tagName: "table", className: "has-fixed-layout" }),
+    tagNames: ["th", "td"],
+    attributeName: "align",
+  });
+}
+
+function normalizeImageHtml(html: string): string {
+  const imageBlockHtml = addClassToOpeningTag({ html, tagName: "figure", className: WORDPRESS_IMAGE_CLASS });
+  const largeImageHtml = addClassToOpeningTag({ html: imageBlockHtml, tagName: "figure", className: "size-large" });
+  const withoutFigureStyle = stripAttributeFromElements({
+    html: largeImageHtml,
+    tagNames: ["figure"],
+    attributeName: "style",
+  });
+
+  return ["style", "srcset", "sizes", "loading", "decoding", "fetchpriority"].reduce((content, attributeName) => {
+    return stripAttributeFromElements({ html: content, tagNames: ["img"], attributeName });
+  }, withoutFigureStyle);
+}
+
+function getBlockAttributesFromClasses({
+  html,
+  baseClassName,
+  ignoredClassNames,
+}: {
+  html: string;
+  baseClassName: string;
+  ignoredClassNames?: readonly string[];
+}): WordPressBlockAttributes {
+  const className = getBlockClassName({ html, baseClassName, ignoredClassNames });
+  return className ? { className } : {};
+}
+
+function normalizeRootElementBlock({
+  blockName,
+  html,
+  rootTagName,
+  baseClassName,
+  captionClassName,
+  stripRootStyles = false,
+  stripImageStyles = false,
+}: RootElementBlock): string {
+  const rootHtml = addClassToOpeningTag({ html, tagName: rootTagName, className: baseClassName });
+  const rootStyleHtml = stripRootStyles
+    ? stripAttributeFromElements({ html: rootHtml, tagNames: [rootTagName], attributeName: "style" })
+    : rootHtml;
+  const contentHtml = stripImageStyles
+    ? stripAttributeFromElements({ html: rootStyleHtml, tagNames: ["img"], attributeName: "style" })
+    : rootStyleHtml;
+  const normalizedHtml = captionClassName
+    ? addClassToElements({ html: contentHtml, tagName: "figcaption", className: captionClassName })
+    : contentHtml;
+
+  return wrapWordPressBlock({
+    blockName,
+    html: normalizedHtml,
+    attributes: getBlockAttributesFromClasses({ html: normalizedHtml, baseClassName }),
+  });
 }
 
 function findElementEnd({ html, startIndex, tagName }: { html: string; startIndex: number; tagName: string }): number {
@@ -152,9 +297,44 @@ function splitTopLevelHtml(html: string): string[] {
 }
 
 function serializeTableBlock(html: string): string {
-  const className = getBlockClassName(html, "wp-block-table");
-  const attributes: WordPressBlockAttributes = className ? { className } : {};
-  return wrapWordPressBlock({ blockName: "table", html, attributes });
+  return normalizeRootElementBlock({
+    blockName: "table",
+    html: normalizeTableHtml(html),
+    rootTagName: "figure",
+    baseClassName: WORDPRESS_TABLE_CLASS,
+    captionClassName: WORDPRESS_CAPTION_CLASS,
+  });
+}
+
+function serializeImageBlock(html: string): string {
+  const normalizedHtml = addClassToElements({
+    html: normalizeImageHtml(html),
+    tagName: "figcaption",
+    className: WORDPRESS_CAPTION_CLASS,
+  });
+
+  return wrapWordPressBlock({
+    blockName: "image",
+    html: normalizedHtml,
+    attributes: {
+      sizeSlug: "large",
+      linkDestination: "none",
+      ...getBlockAttributesFromClasses({
+        html: normalizedHtml,
+        baseClassName: WORDPRESS_IMAGE_CLASS,
+        ignoredClassNames: ["size-large"],
+      }),
+    },
+  });
+}
+
+function serializeQuoteBlock(html: string): string {
+  return normalizeRootElementBlock({
+    blockName: "quote",
+    html,
+    rootTagName: "blockquote",
+    baseClassName: WORDPRESS_QUOTE_CLASS,
+  });
 }
 
 function serializeHeadingBlock({ html, tagName }: { html: string; tagName: string }): string {
@@ -180,7 +360,7 @@ function serializeKnownBlock(html: string): string {
   }
 
   if (tagName === "figure" && /<img\b/i.test(html)) {
-    return wrapWordPressBlock({ blockName: "image", html });
+    return serializeImageBlock(html);
   }
 
   if (tagName === "p") {
@@ -196,7 +376,7 @@ function serializeKnownBlock(html: string): string {
   }
 
   if (tagName === "blockquote") {
-    return wrapWordPressBlock({ blockName: "quote", html });
+    return serializeQuoteBlock(html);
   }
 
   if (tagName === "pre") {

--- a/src/lib/wordpress-blocks.ts
+++ b/src/lib/wordpress-blocks.ts
@@ -6,8 +6,6 @@ type RootElementBlock = {
   rootTagName: string;
   baseClassName: string;
   captionClassName?: string;
-  stripRootStyles?: boolean;
-  stripImageStyles?: boolean;
 };
 
 const VOID_HTML_TAGS = new Set([
@@ -168,15 +166,11 @@ function normalizeTableHtml(html: string): string {
 function normalizeImageHtml(html: string): string {
   const imageBlockHtml = addClassToOpeningTag({ html, tagName: "figure", className: WORDPRESS_IMAGE_CLASS });
   const largeImageHtml = addClassToOpeningTag({ html: imageBlockHtml, tagName: "figure", className: "size-large" });
-  const withoutFigureStyle = stripAttributeFromElements({
+  return stripAttributeFromElements({
     html: largeImageHtml,
     tagNames: ["figure"],
     attributeName: "style",
   });
-
-  return ["style", "srcset", "sizes", "loading", "decoding", "fetchpriority"].reduce((content, attributeName) => {
-    return stripAttributeFromElements({ html: content, tagNames: ["img"], attributeName });
-  }, withoutFigureStyle);
 }
 
 function getBlockAttributesFromClasses({
@@ -198,19 +192,11 @@ function normalizeRootElementBlock({
   rootTagName,
   baseClassName,
   captionClassName,
-  stripRootStyles = false,
-  stripImageStyles = false,
 }: RootElementBlock): string {
   const rootHtml = addClassToOpeningTag({ html, tagName: rootTagName, className: baseClassName });
-  const rootStyleHtml = stripRootStyles
-    ? stripAttributeFromElements({ html: rootHtml, tagNames: [rootTagName], attributeName: "style" })
-    : rootHtml;
-  const contentHtml = stripImageStyles
-    ? stripAttributeFromElements({ html: rootStyleHtml, tagNames: ["img"], attributeName: "style" })
-    : rootStyleHtml;
   const normalizedHtml = captionClassName
-    ? addClassToElements({ html: contentHtml, tagName: "figcaption", className: captionClassName })
-    : contentHtml;
+    ? addClassToElements({ html: rootHtml, tagName: "figcaption", className: captionClassName })
+    : rootHtml;
 
   return wrapWordPressBlock({
     blockName,


### PR DESCRIPTION
## Summary
- sync managed vault AGENTS.md rules without overwriting user content
- document generated article indexes as build artifacts for agents
- normalize WordPress quote, image, and table block serialization, including after-media/table captions

## Validation
- npm run type-check
- npm run test -- src/lib/wordpress-blocks.test.ts src/lib/markdown.test.ts scripts/lib/wordpress.test.ts scripts/lib/agent-rules.test.ts