### PR TITLE
Add wikilinks, rendered cache, and WordPress image normalization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - **Never** include absolute filesystem paths (e.g., `/Users/username/...`) in any code, documentation, or commit messages.
 - Always use **relative paths** for internal links and documentation.
 - If an absolute path is required for local configuration, use placeholder strings or rely strictly on environment variables.
+- Use generic examples in code comments, tests, documentation, and commit messages. Avoid exposing user-specific or developer-specific details, private identifiers, production values, credentials, or personal content unless the user explicitly asks to edit or document that exact information.
 
 # Skills
 Consult the `skills/` directory for specific guides and automation patterns:

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Notopress is designed to fit seamlessly into your existing workflow, rather than
 - **Sitemap generation**: `sitemap.xml` is generated when a site `domain` is configured, with nested sitemap indexes for larger directory trees.
 - **Static asset serving**: Files in `public/` and supported asset files in `content/` are served from S3-compatible storage through the app.
 - **Responsive images**: Supported local images are converted to WebP thumbnails and rendered with `srcset`, lazy loading, and async decoding.
-- **Obsidian image embeds**: Local image wikilinks such as `![[image.png]]` are resolved against known public/content assets.
-- **Private note transclusions**: Reusable notes outside `content/` can be embedded with `![[note-name]]` through configured `noteIncludePaths` without becoming public pages.
+- **Obsidian image embeds**: Local image wikilinks such as `![[image.png]]` are resolved against known public/content assets and render through the same image pipeline as `![](...)`.
+- **Note wikilinks**: Public notes can be linked with `[[note-slug]]` or `[[folder/note-slug]]`, using the target note title as link text.
+- **Note transclusions**: Public notes and configured private snippets can be embedded with `![[note-slug]]`, including nested transclusions.
 - **Multi-site registry**: Manage multiple sites from one `registry.json`, each with its own `siteId`, domain, bucket, endpoint, and local content path.
 - **Content sync**: Generate indices, rendered HTML, sitemaps, thumbnails, and upload content to S3-compatible storage with delete synchronization.
 - **Dry runs**: Preview generated files and storage changes before writing with `--dry-run`.
@@ -109,15 +110,52 @@ Generated thumbnails live under `_thumbnails/` beside the source tree that owns 
 
 Rendered HTML files are generated under `_rendered/content/` during sync. They are cache artifacts like thumbnails and indexes: source Markdown remains the source of truth.
 
-### Private Note Includes
+### Wikilinks and Note Transclusions
 
-Use `noteIncludePaths` for reusable Markdown snippets that should be transcluded into articles but should not have their own public URLs. For example, a vault file at `_includes/vpn-promotion-for-games.md` can be embedded from a public article with:
+Notopress supports a subset of Obsidian-style wikilinks for local images, note links, and note transclusions.
+
+Image embeds resolve against known files in `content/` and `public/`:
 
 ```markdown
-![[vpn-promotion-for-games]]
+![[image.png]]
+![[attachments/image.png|Alt text]]
 ```
 
-Normal links like `[[vpn-promotion-for-games]]` still only resolve to public notes under `content/`.
+These render through the same responsive image pipeline as standard Markdown images:
+
+```markdown
+![Alt text](attachments/image.png)
+```
+
+Public note links resolve against Markdown files under `content/`:
+
+```markdown
+[[guide-note]]
+[[docs/guide-note]]
+[[guide-note|Custom link text]]
+```
+
+When a note link is rendered, Notopress uses the target note's title as the default link text. Nested notes keep their full public URL path, so `[[docs/guide-note]]` links to `/docs/guide-note`.
+
+If a target leaf slug is unique, `[[guide-note]]` can resolve without the folder path. If multiple notes share the same filename, use the nested path form to avoid ambiguity.
+
+Use `![[note-slug]]` to transclude note content:
+
+```markdown
+![[shared-callout]]
+```
+
+Transclusions render only the referenced note body. Frontmatter and the first top-level heading are removed so reusable snippets do not duplicate their own title inside the host article. Transcluded content is processed recursively, so an embedded note can include other note links or transclusions.
+
+Private reusable snippets can live outside `content/` by configuring `noteIncludePaths`. For example:
+
+```json
+{
+  "noteIncludePaths": ["_includes"]
+}
+```
+
+A vault file at `_includes/shared-callout.md` can then be embedded with `![[shared-callout]]` without becoming a public page. Private include notes are embed-only: normal links such as `[[shared-callout]]` resolve only when the target is a public note under `content/`.
 
 ### Serving Thumbnails from Cloudflare
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Notopress is designed to fit seamlessly into your existing workflow, rather than
 - **Static asset serving**: Files in `public/` and supported asset files in `content/` are served from S3-compatible storage through the app.
 - **Responsive images**: Supported local images are converted to WebP thumbnails and rendered with `srcset`, lazy loading, and async decoding.
 - **Obsidian image embeds**: Local image wikilinks such as `![[image.png]]` are resolved against known public/content assets.
+- **Private note transclusions**: Reusable notes outside `content/` can be embedded with `![[note-name]]` through configured `noteIncludePaths` without becoming public pages.
 - **Multi-site registry**: Manage multiple sites from one `registry.json`, each with its own `siteId`, domain, bucket, endpoint, and local content path.
-- **Content sync**: Generate indices, sitemaps, thumbnails, and upload content to S3-compatible storage with delete synchronization.
+- **Content sync**: Generate indices, rendered HTML, sitemaps, thumbnails, and upload content to S3-compatible storage with delete synchronization.
 - **Dry runs**: Preview generated files and storage changes before writing with `--dry-run`.
 - **Local environment switching**: Use `npm run configure` to update `.env.local` for a selected site.
 - **Vercel deployment automation**: Sync production environment variables and trigger a production Vercel deploy with `npm run deploy`.
@@ -92,6 +93,7 @@ The registry manages global defaults and site-specific overrides.
 | `domain` | `string` | (Optional) Your site's domain. Used to generate absolute URLs for the sitemap. If omitted, sitemap generation will be skipped. |
 | `siteId` | `string` | A unique ID for the site, used as its root folder in S3. |
 | `vaultPath` | `string` | Path to the local Markdown folder that acts as the source of truth for this site. |
+| `noteIncludePaths` | `string[]` | (Optional) Vault-relative folders for private Markdown snippets that can be embedded with `![[note-name]]` but are not routed as public pages. |
 | `bucketName` | `string` | (Optional) The S3 bucket name. |
 | `endpoint` | `string` | (Optional) Override the global endpoint for this site. |
 | `vercelProjectId` | `string` | (Optional) Vercel project ID to deploy. Falls back to `siteId` when omitted. |
@@ -104,6 +106,18 @@ The registry manages global defaults and site-specific overrides.
 When you run `npm run sync`, Notopress creates WebP thumbnails for supported images in `content/` and `public/`, then includes them in generated responsive `srcset` attributes at render time.
 
 Generated thumbnails live under `_thumbnails/` beside the source tree that owns the image. For example, an image referenced as `/attachments/photo.png` gets thumbnail candidates like `/_thumbnails/attachments/photo-640.webp`.
+
+Rendered HTML files are generated under `_rendered/content/` during sync. They are cache artifacts like thumbnails and indexes: source Markdown remains the source of truth.
+
+### Private Note Includes
+
+Use `noteIncludePaths` for reusable Markdown snippets that should be transcluded into articles but should not have their own public URLs. For example, a vault file at `_includes/vpn-promotion-for-games.md` can be embedded from a public article with:
+
+```markdown
+![[vpn-promotion-for-games]]
+```
+
+Normal links like `[[vpn-promotion-for-games]]` still only resolve to public notes under `content/`.
 
 ### Serving Thumbnails from Cloudflare
 
@@ -156,7 +170,7 @@ To generate content metadata, generate sitemaps, upload the local content folder
 npm run sync
 ```
 
-The sync command writes generated files such as `root.json`, nested content indices, responsive thumbnails, and `sitemap.xml` files before uploading. Each site is uploaded under its `siteId` prefix in the configured bucket.
+The sync command writes generated files such as `root.json`, nested content indices, rendered HTML, responsive thumbnails, and `sitemap.xml` files before uploading. Each site is uploaded under its `siteId` prefix in the configured bucket.
 
 ### Safety First: Dry Run
 Before making any changes, you can preview what will happen:

--- a/registry.json.example
+++ b/registry.json.example
@@ -9,6 +9,7 @@
       "domain": "example.com",
       "siteId": "example-blog",
       "vaultPath": "/absolute/path/to/your/obsidian/vault",
+      "noteIncludePaths": ["_includes"],
       "bucketName": "your-r2-bucket-name",
       "vercelProjectId": "your-vercel-project-id",
       "endpoint": "https://your-custom-s3-endpoint.com",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -14,6 +14,7 @@ import { generateIndices } from './lib/indices';
 import { generateSitemaps } from './lib/sitemaps';
 import { pushToWordPress, pullFromWordPress } from './lib/wordpress';
 import { ensureVaultAgentRules } from './lib/agent-rules';
+import { generateRenderedContent } from './lib/rendered-content';
 
 type CommandResult = {
   status: number | null;
@@ -401,9 +402,19 @@ async function syncContent({
   const thumbnailSizes = normalizeThumbnailSizes(site.thumbnailSizes || registry.thumbnailSizes);
   await ensureVaultAgentRules({ vaultPath: site.vaultPath, dryRun: isDryRun });
 
-  const { rootContentIndex, allIndices } = await generateIndices({
+  const { rootContentIndex, vaultRootIndex, allIndices } = await generateIndices({
     vaultPath: site.vaultPath,
     thumbnailSizes,
+    noteIncludePaths: site.noteIncludePaths,
+    dryRun: isDryRun,
+  });
+
+  await generateRenderedContent({
+    vaultPath: site.vaultPath,
+    allIndices,
+    rootIndex: vaultRootIndex,
+    thumbnailSizes,
+    noteIncludePaths: site.noteIncludePaths,
     dryRun: isDryRun,
   });
 
@@ -462,6 +473,7 @@ async function main() {
       const { allIndices } = await generateIndices({
         vaultPath: site.vaultPath,
         thumbnailSizes,
+        noteIncludePaths: site.noteIncludePaths,
         dryRun: true,
       });
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -411,6 +411,8 @@ async function syncContent({
 
   await generateRenderedContent({
     vaultPath: site.vaultPath,
+    siteId: site.siteId,
+    imageHost: site.imageHost || registry.imageHost,
     allIndices,
     rootIndex: vaultRootIndex,
     thumbnailSizes,

--- a/scripts/lib/indices.test.ts
+++ b/scripts/lib/indices.test.ts
@@ -16,17 +16,21 @@ describe('createIndexGenerator', () => {
     const tree: Record<string, FileEntry[]> = {
       'vault/content': [file('page.md'), directory('blog'), file('hero.png')],
       'vault/content/blog': [file('post.md')],
+      'vault/_includes': [file('vpn-promotion-for-games.md')],
     };
     const fileContent: Record<string, string> = {
       'vault/content/page.md': 'home',
       'vault/content/blog/post.md': 'post',
+      'vault/_includes/vpn-promotion-for-games.md': 'include',
     };
     const writes: Record<string, string> = {};
     const generateImageThumbnails = vi.fn(async () => undefined);
     const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
     const generator = createIndexGenerator({
-      exists: vi.fn(async (filePath: string) => filePath === 'vault/content' || filePath === 'vault/public'),
+      exists: vi.fn(async (filePath: string) =>
+        filePath === 'vault/content' || filePath === 'vault/public' || filePath === 'vault/_includes'
+      ),
       mkdir: vi.fn(async () => undefined),
       readdir: vi.fn(async (filePath: string) => tree[filePath] || []),
       readFile: vi.fn(async (filePath: string) => fileContent[filePath] || ''),
@@ -39,6 +43,8 @@ describe('createIndexGenerator', () => {
       parseMatter: (content) =>
         content === 'home'
           ? { data: { title: 'Home', date: '2024-01-02' }, content: '# Home\nIntro text' }
+          : content === 'include'
+          ? { data: { title: 'VPN Promotion' }, content: '# VPN Promotion\nPrivate body' }
           : { data: {}, content: '# Post\nPost excerpt' },
       normalizeThumbnailSizes: (sizes) => [...(sizes || [])],
       scanPublicFiles: vi.fn(async () => ['sitemap.xml', '_thumbnails/logo-320.webp']),
@@ -50,6 +56,7 @@ describe('createIndexGenerator', () => {
     const result = await generator.generateIndices({
       vaultPath: 'vault',
       thumbnailSizes: [320, 640],
+      noteIncludePaths: ['_includes'],
       dryRun: false,
     });
 
@@ -59,6 +66,14 @@ describe('createIndexGenerator', () => {
       directories: ['blog'],
       publicFiles: ['sitemap.xml'],
       assetFiles: ['hero.png', 'sitemap.xml'],
+      noteIncludes: [
+        {
+          fullSlug: 'vpn-promotion-for-games',
+          title: 'VPN Promotion',
+          filePath: '_includes/vpn-promotion-for-games.md',
+          linkable: false,
+        },
+      ],
       thumbnailSizes: [320, 640],
     });
     expect(generateImageThumbnails).toHaveBeenCalledWith({

--- a/scripts/lib/indices.ts
+++ b/scripts/lib/indices.ts
@@ -15,6 +15,13 @@ type MatterResult = {
   content: string;
 };
 
+type NoteIncludeMetadata = {
+  fullSlug: string;
+  title: string;
+  filePath: string;
+  linkable: false;
+};
+
 export type IndexGeneratorDeps = {
   exists: (path: string) => Promise<boolean>;
   mkdir: (path: string, options: { recursive: true }) => Promise<string | undefined>;
@@ -77,7 +84,68 @@ function excludeGeneratedFiles(files: readonly string[]): string[] {
   return files.filter((file) => !isGeneratedThumbnailPath(file));
 }
 
+function normalizeIncludePath(includePath: string): string {
+  return includePath.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
 export function createIndexGenerator(deps: IndexGeneratorDeps) {
+  async function scanNoteIncludes({
+    vaultPath,
+    noteIncludePaths,
+  }: {
+    vaultPath: string;
+    noteIncludePaths?: readonly string[];
+  }): Promise<NoteIncludeMetadata[]> {
+    const noteIncludes: NoteIncludeMetadata[] = [];
+    if (!noteIncludePaths || noteIncludePaths.length === 0) {
+      return noteIncludes;
+    }
+
+    for (const includePath of noteIncludePaths) {
+      const normalizedIncludePath = normalizeIncludePath(includePath);
+      if (!normalizedIncludePath || normalizedIncludePath === 'content' || normalizedIncludePath.startsWith('content/')) {
+        continue;
+      }
+
+      const includeDir = deps.joinPath(vaultPath, normalizedIncludePath);
+      async function walk(currentDir: string): Promise<void> {
+        if (!(await deps.exists(currentDir))) {
+          return;
+        }
+
+        const entries = await deps.readdir(currentDir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = deps.joinPath(currentDir, entry.name);
+          if (entry.isDirectory()) {
+            if (entry.name !== '.git' && entry.name !== 'node_modules') {
+              await walk(fullPath);
+            }
+          } else if (entry.isFile() && entry.name.endsWith('.md')) {
+            const relIncludePath = deps.relativePath(includeDir, fullPath).replace(/\\/g, '/');
+            const fullSlug = relIncludePath.replace(/\.md$/i, '');
+            const fileContent = await deps.readFile(fullPath, 'utf-8');
+            const { data, content } = deps.parseMatter(fileContent);
+            const titleMatch = content.match(/^#\s+(.+)$/m);
+            const title =
+              typeof data.title === 'string' && data.title.trim()
+                ? data.title.trim()
+                : titleMatch?.[1]?.trim() || fullSlug.split('/').pop() || fullSlug;
+            noteIncludes.push({
+              fullSlug,
+              title,
+              filePath: `${normalizedIncludePath}/${relIncludePath}`,
+              linkable: false,
+            });
+          }
+        }
+      }
+
+      await walk(includeDir);
+    }
+
+    return noteIncludes.sort((a, b) => a.fullSlug.localeCompare(b.fullSlug));
+  }
+
   async function scanAndGenerate({
     dir,
     baseDir,
@@ -184,12 +252,18 @@ export function createIndexGenerator(deps: IndexGeneratorDeps) {
     async generateIndices({
       vaultPath,
       thumbnailSizes,
+      noteIncludePaths,
       dryRun = false,
     }: {
       vaultPath: string;
       thumbnailSizes: readonly number[];
+      noteIncludePaths?: readonly string[];
       dryRun?: boolean;
-    }): Promise<{ rootContentIndex: VaultDirectoryIndex; allIndices: Map<string, VaultDirectoryIndex> }> {
+    }): Promise<{
+      rootContentIndex: VaultDirectoryIndex;
+      vaultRootIndex: VaultRootIndex;
+      allIndices: Map<string, VaultDirectoryIndex>;
+    }> {
       const contentDir = deps.joinPath(vaultPath, 'content');
       if (!(await deps.exists(contentDir))) {
         throw new Error(`The required "content" directory is missing in the vault: ${vaultPath}`);
@@ -227,6 +301,7 @@ export function createIndexGenerator(deps: IndexGeneratorDeps) {
       ).sort();
       const contentAssetFiles = excludeGeneratedFiles(await deps.scanContentAssetFiles({ dir: contentDir }));
       const assetFiles = [...new Set([...publicFiles, ...contentAssetFiles])].sort();
+      const noteIncludes = await scanNoteIncludes({ vaultPath, noteIncludePaths });
 
       const rootPath = deps.joinPath(vaultPath, ROOT_JSON);
       const vaultRootIndex: VaultRootIndex = {
@@ -234,6 +309,7 @@ export function createIndexGenerator(deps: IndexGeneratorDeps) {
         directories: allDirs,
         publicFiles,
         assetFiles,
+        noteIncludes,
         thumbnailSizes: deps.normalizeThumbnailSizes(thumbnailSizes),
       };
 
@@ -244,7 +320,7 @@ export function createIndexGenerator(deps: IndexGeneratorDeps) {
         deps.logger.log(`✨ Generated master root index with ${allDirs.length} directories at: ${rootPath}`);
       }
 
-      return { rootContentIndex, allIndices };
+      return { rootContentIndex, vaultRootIndex, allIndices };
     },
   };
 }

--- a/scripts/lib/note-includes.ts
+++ b/scripts/lib/note-includes.ts
@@ -1,0 +1,206 @@
+import { readdir, readFile } from 'fs/promises';
+import path from 'path';
+import matter from 'gray-matter';
+import {
+  createNoteReferenceResolver,
+  extractWikilinkTargets,
+  type NoteReference,
+  type NoteReferenceInput,
+} from '../../src/lib/note-links';
+
+type NoteIncludeSource = {
+  fullSlug: string;
+  title: string;
+  filePath: string;
+  linkable: false;
+};
+
+type Logger = Pick<typeof console, 'warn'>;
+
+function stripFirstMarkdownHeading(markdown: string): string {
+  return markdown.replace(/^#\s+.+$/m, '').trim();
+}
+
+function getTitleFromMarkdown({ markdown, fallback }: { markdown: string; fallback: string }): string {
+  const { data, content } = matter(markdown);
+  if (typeof data.title === 'string' && data.title.trim()) {
+    return data.title.trim();
+  }
+  const titleMatch = content.match(/^#\s+(.+)$/m);
+  return titleMatch?.[1]?.trim() || fallback;
+}
+
+function normalizeIncludePath(includePath: string): string {
+  return includePath.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+async function scanMarkdownFiles({ dir, baseDir }: { dir: string; baseDir: string }): Promise<string[]> {
+  const files: string[] = [];
+
+  async function walk(currentDir: string): Promise<void> {
+    const entries = await readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== '.git' && entry.name !== 'node_modules') {
+          await walk(fullPath);
+        }
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        files.push(path.relative(baseDir, fullPath).replace(/\\/g, '/'));
+      }
+    }
+  }
+
+  await walk(dir);
+  return files;
+}
+
+export async function collectPrivateNoteIncludes({
+  vaultPath,
+  includePaths,
+  logger = console,
+}: {
+  vaultPath: string;
+  includePaths?: readonly string[];
+  logger?: Logger;
+}): Promise<NoteReferenceInput[]> {
+  const includeSources: NoteIncludeSource[] = [];
+  if (!includePaths || includePaths.length === 0) {
+    return includeSources;
+  }
+
+  for (const includePath of includePaths) {
+    const normalizedPath = normalizeIncludePath(includePath);
+    if (!normalizedPath || normalizedPath === 'content' || normalizedPath.startsWith('content/')) {
+      continue;
+    }
+
+    const fullIncludePath = path.join(vaultPath, normalizedPath);
+    try {
+      const markdownFiles = await scanMarkdownFiles({ dir: fullIncludePath, baseDir: fullIncludePath });
+      for (const markdownFile of markdownFiles) {
+        const filePath = path.join(fullIncludePath, markdownFile);
+        const fileContent = await readFile(filePath, 'utf-8');
+        const slug = markdownFile.replace(/\.md$/i, '');
+        includeSources.push({
+          fullSlug: slug,
+          title: getTitleFromMarkdown({
+            markdown: fileContent,
+            fallback: path.basename(slug),
+          }),
+          linkable: false,
+          filePath,
+        });
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`  ⚠️  Failed to scan note include path "${normalizedPath}": ${message}`);
+    }
+  }
+
+  return includeSources;
+}
+
+function buildPrivateSourcesBySlug({
+  privateNoteReferences,
+}: {
+  privateNoteReferences: readonly NoteReferenceInput[];
+}): Map<string, NoteIncludeSource> {
+  const sources = new Map<string, NoteIncludeSource>();
+  for (const note of privateNoteReferences) {
+    if ('filePath' in note && typeof note.filePath === 'string') {
+      const source: NoteIncludeSource = {
+        fullSlug: note.fullSlug,
+        title: note.title,
+        filePath: note.filePath,
+        linkable: false,
+      };
+      sources.set(note.fullSlug, source);
+    }
+  }
+  return sources;
+}
+
+export async function collectNoteReferencesForLocalMarkdown({
+  publicNoteReferences,
+  privateNoteReferences = [],
+  markdown,
+  readPublicNote,
+  logger = console,
+}: {
+  publicNoteReferences: readonly NoteReferenceInput[];
+  privateNoteReferences?: readonly NoteReferenceInput[];
+  markdown: string;
+  readPublicNote: ({ fullSlug }: { fullSlug: string }) => Promise<string>;
+  logger?: Logger;
+}): Promise<NoteReference[]> {
+  const wikilinkTargets = extractWikilinkTargets(markdown);
+  if (wikilinkTargets.links.length === 0 && wikilinkTargets.embeds.length === 0) {
+    return [];
+  }
+
+  const publicResolver = createNoteReferenceResolver({ notes: publicNoteReferences });
+  const embedResolver = createNoteReferenceResolver({ notes: [...publicNoteReferences, ...privateNoteReferences] });
+  const privateSourcesBySlug = buildPrivateSourcesBySlug({ privateNoteReferences });
+  const referencesByFullSlug = new Map<string, NoteReference>();
+  const embedTargetsToFetch = [...wikilinkTargets.embeds];
+  const fetchedEmbedSlugs = new Set<string>();
+
+  for (const target of wikilinkTargets.links) {
+    const reference = publicResolver.resolve({ target });
+    if (reference) {
+      referencesByFullSlug.set(reference.fullSlug, reference);
+    }
+  }
+
+  for (const target of wikilinkTargets.embeds) {
+    const reference = embedResolver.resolve({ target });
+    if (reference) {
+      referencesByFullSlug.set(reference.fullSlug, reference);
+    }
+  }
+
+  while (embedTargetsToFetch.length > 0) {
+    const target = embedTargetsToFetch.shift();
+    if (!target) {
+      continue;
+    }
+
+    const reference = embedResolver.resolve({ target });
+    if (!reference || fetchedEmbedSlugs.has(reference.fullSlug)) {
+      continue;
+    }
+    fetchedEmbedSlugs.add(reference.fullSlug);
+
+    try {
+      const privateSource = privateSourcesBySlug.get(reference.fullSlug);
+      const embeddedMarkdown = privateSource ? await readFile(privateSource.filePath, 'utf-8') : await readPublicNote(reference);
+      const { content } = matter(embeddedMarkdown);
+      const bodyContent = stripFirstMarkdownHeading(content);
+      referencesByFullSlug.set(reference.fullSlug, {
+        ...reference,
+        content: bodyContent,
+      });
+
+      const nestedTargets = extractWikilinkTargets(bodyContent);
+      for (const nestedTarget of nestedTargets.links) {
+        const nestedReference = publicResolver.resolve({ target: nestedTarget });
+        if (nestedReference) {
+          referencesByFullSlug.set(nestedReference.fullSlug, nestedReference);
+        }
+      }
+      for (const nestedTarget of nestedTargets.embeds) {
+        const nestedReference = embedResolver.resolve({ target: nestedTarget });
+        if (nestedReference) {
+          referencesByFullSlug.set(nestedReference.fullSlug, nestedReference);
+        }
+      }
+      embedTargetsToFetch.push(...nestedTargets.embeds);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`  ⚠️  Failed to read embedded note "${reference.fullSlug}": ${message}`);
+    }
+  }
+
+  return [...referencesByFullSlug.values()];
+}

--- a/scripts/lib/rendered-content.test.ts
+++ b/scripts/lib/rendered-content.test.ts
@@ -13,7 +13,18 @@ describe('rendered content generator', () => {
       await mkdir(path.join(vaultPath, 'templates'), { recursive: true });
       await writeFile(
         path.join(vaultPath, 'content', 'post-one.md'),
-        ['---', 'title: "Post One"', '---', '# Post One', '', 'Before.', '', '![[promo-note]]'].join('\n')
+        [
+          '---',
+          'title: "Post One"',
+          '---',
+          '# Post One',
+          '',
+          'Before.',
+          '',
+          '![Hero](hero.png)',
+          '',
+          '![[promo-note]]',
+        ].join('\n')
       );
       await writeFile(
         path.join(vaultPath, 'templates', 'promo-note.md'),
@@ -47,6 +58,7 @@ describe('rendered content generator', () => {
 
       await generateRenderedContent({
         vaultPath,
+        siteId: 'test-blog',
         allIndices,
         rootIndex,
         thumbnailSizes: [320],
@@ -59,6 +71,7 @@ describe('rendered content generator', () => {
 
       expect(rendered).toContain('Before.');
       expect(rendered).toContain('Private promotion body.');
+      expect(rendered).toContain('src="/api/vault-public/_thumbnails/hero-320.webp"');
       expect(rendered).not.toContain('![[promo-note]]');
       expect(rendered).not.toContain('<h1>Post One</h1>');
     } finally {

--- a/scripts/lib/rendered-content.test.ts
+++ b/scripts/lib/rendered-content.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+import { tmpdir } from 'os';
+import { generateRenderedContent, getRenderedContentPath } from './rendered-content';
+import { VaultDirectoryIndex, VaultRootIndex } from '../../src/lib/vault';
+
+describe('rendered content generator', () => {
+  it('generates cached HTML for public content with private note transclusions', async () => {
+    const vaultPath = await mkdtemp(path.join(tmpdir(), 'notopress-rendered-'));
+    try {
+      await mkdir(path.join(vaultPath, 'content'), { recursive: true });
+      await mkdir(path.join(vaultPath, 'templates'), { recursive: true });
+      await writeFile(
+        path.join(vaultPath, 'content', 'post-one.md'),
+        ['---', 'title: "Post One"', '---', '# Post One', '', 'Before.', '', '![[promo-note]]'].join('\n')
+      );
+      await writeFile(
+        path.join(vaultPath, 'templates', 'promo-note.md'),
+        ['---', 'title: "Promo Note"', '---', '# Promo Note', '', 'Private promotion body.'].join('\n')
+      );
+
+      const allIndices = new Map<string, VaultDirectoryIndex>([
+        [
+          '',
+          {
+            version: 1,
+            pages: [{ title: 'Post One', slug: 'post-one', date: '2026-01-01T00:00:00.000Z', excerpt: '' }],
+          },
+        ],
+      ]);
+      const rootIndex: VaultRootIndex = {
+        version: 1,
+        pages: [{ title: 'Post One', slug: 'post-one', date: '2026-01-01T00:00:00.000Z', excerpt: '' }],
+        directories: [],
+        publicFiles: [],
+        assetFiles: [],
+        noteIncludes: [
+          {
+            fullSlug: 'promo-note',
+            title: 'Promo Note',
+            filePath: 'templates/promo-note.md',
+            linkable: false,
+          },
+        ],
+      };
+
+      await generateRenderedContent({
+        vaultPath,
+        allIndices,
+        rootIndex,
+        thumbnailSizes: [320],
+        noteIncludePaths: ['templates'],
+        dryRun: false,
+        logger: { log: vi.fn() },
+      });
+
+      const rendered = await readFile(path.join(vaultPath, getRenderedContentPath({ fullSlug: 'post-one' })), 'utf-8');
+
+      expect(rendered).toContain('Before.');
+      expect(rendered).toContain('Private promotion body.');
+      expect(rendered).not.toContain('![[promo-note]]');
+      expect(rendered).not.toContain('<h1>Post One</h1>');
+    } finally {
+      await rm(vaultPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/lib/rendered-content.ts
+++ b/scripts/lib/rendered-content.ts
@@ -1,0 +1,89 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import matter from 'gray-matter';
+import { RENDERED_DIR } from '../../src/lib/constants';
+import { renderMarkdownContent } from '../../src/lib/markdown';
+import { VaultDirectoryIndex, VaultRootIndex } from '../../src/lib/vault';
+import { type NoteReferenceInput } from '../../src/lib/note-links';
+import { collectNoteReferencesForLocalMarkdown, collectPrivateNoteIncludes } from './note-includes';
+
+type Logger = Pick<typeof console, 'log'>;
+
+function stripFirstMarkdownHeading(markdown: string): string {
+  return markdown.replace(/^#\s+.+$/m, '').trim();
+}
+
+function buildPublicNoteReferences({ allIndices }: { allIndices: Map<string, VaultDirectoryIndex> }): NoteReferenceInput[] {
+  const noteReferences: NoteReferenceInput[] = [];
+  for (const [dirKey, dirIndex] of allIndices.entries()) {
+    for (const page of dirIndex.pages) {
+      noteReferences.push({
+        fullSlug: dirKey ? `${dirKey}/${page.slug}` : page.slug,
+        title: page.title,
+      });
+    }
+  }
+  return noteReferences;
+}
+
+export function getRenderedContentPath({ fullSlug }: { fullSlug: string }): string {
+  return `${RENDERED_DIR}/content/${fullSlug}.html`;
+}
+
+export async function generateRenderedContent({
+  vaultPath,
+  allIndices,
+  rootIndex,
+  thumbnailSizes,
+  noteIncludePaths,
+  dryRun,
+  logger = console,
+}: {
+  vaultPath: string;
+  allIndices: Map<string, VaultDirectoryIndex>;
+  rootIndex: VaultRootIndex;
+  thumbnailSizes: readonly number[];
+  noteIncludePaths?: readonly string[];
+  dryRun: boolean;
+  logger?: Logger;
+}): Promise<void> {
+  const assetFiles = rootIndex.assetFiles || rootIndex.publicFiles;
+  const publicNoteReferences = buildPublicNoteReferences({ allIndices });
+  const privateNoteReferences = await collectPrivateNoteIncludes({ vaultPath, includePaths: noteIncludePaths });
+  let renderedCount = 0;
+
+  for (const [dirKey, dirIndex] of allIndices.entries()) {
+    for (const page of dirIndex.pages) {
+      const fullSlug = dirKey ? `${dirKey}/${page.slug}` : page.slug;
+      const markdownPath = path.join(vaultPath, 'content', `${fullSlug}.md`);
+      const renderedPath = path.join(vaultPath, getRenderedContentPath({ fullSlug }));
+      const markdownFile = await readFile(markdownPath, 'utf-8');
+      const { content } = matter(markdownFile);
+      const markdown = stripFirstMarkdownHeading(content);
+      const noteReferences = await collectNoteReferencesForLocalMarkdown({
+        publicNoteReferences,
+        privateNoteReferences,
+        markdown,
+        readPublicNote: ({ fullSlug: noteSlug }) => readFile(path.join(vaultPath, 'content', `${noteSlug}.md`), 'utf-8'),
+      });
+      const html = await renderMarkdownContent({
+        markdown,
+        thumbnailSizes,
+        assetFiles,
+        noteReferences,
+      });
+
+      if (dryRun) {
+        logger.log(`[DRY RUN] Would generate rendered HTML: ${getRenderedContentPath({ fullSlug })}`);
+      } else {
+        await mkdir(path.dirname(renderedPath), { recursive: true });
+        await writeFile(renderedPath, html);
+      }
+      renderedCount += 1;
+    }
+  }
+
+  if (!dryRun) {
+    logger.log(`✨ Generated ${renderedCount} rendered HTML file(s) in ${RENDERED_DIR}/content`);
+  }
+}

--- a/scripts/lib/rendered-content.ts
+++ b/scripts/lib/rendered-content.ts
@@ -32,6 +32,8 @@ export function getRenderedContentPath({ fullSlug }: { fullSlug: string }): stri
 
 export async function generateRenderedContent({
   vaultPath,
+  siteId,
+  imageHost,
   allIndices,
   rootIndex,
   thumbnailSizes,
@@ -40,6 +42,8 @@ export async function generateRenderedContent({
   logger = console,
 }: {
   vaultPath: string;
+  siteId: string;
+  imageHost?: string;
   allIndices: Map<string, VaultDirectoryIndex>;
   rootIndex: VaultRootIndex;
   thumbnailSizes: readonly number[];
@@ -71,6 +75,12 @@ export async function generateRenderedContent({
         thumbnailSizes,
         assetFiles,
         noteReferences,
+        assetUrlConfig: {
+          imageHost,
+          siteId,
+          s3SubDir: 'content',
+          mode: imageHost ? 'absolute' : 'app-relative',
+        },
       });
 
       if (dryRun) {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -268,11 +268,11 @@ describe('WordPress Deployment Library', () => {
       expect(body.content).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
       expect(body.content).toContain('<figure class="size-large wp-block-image">');
       expect(body.content).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp"');
-      expect(body.content).toContain('srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp 1200w"');
-      expect(body.content).toContain('sizes="(max-width: 1200px) 100vw, 1200px"');
-      expect(body.content).toContain('style="max-width: 100%;"');
-      expect(body.content).toContain('loading="lazy"');
-      expect(body.content).toContain('decoding="async"');
+      expect(body.content).not.toContain('srcset=');
+      expect(body.content).not.toContain('sizes=');
+      expect(body.content).not.toContain('style="max-width: 100%;"');
+      expect(body.content).not.toContain('loading=');
+      expect(body.content).not.toContain('decoding=');
       expect(body.content).toContain('<figcaption class="wp-element-caption">Hero caption</figcaption>');
       expect(body.content).toContain('<!-- /wp:image -->');
       expect(body.content).not.toContain('className":"wp-block-image');
@@ -361,8 +361,8 @@ describe('WordPress Deployment Library', () => {
       expect(body.content).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
       expect(body.content).toContain('<figure class="size-large wp-block-image">');
       expect(body.content).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp"');
-      expect(body.content).toContain('srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp 1200w"');
-      expect(body.content).toContain('sizes="(max-width: 1200px) 100vw, 1200px"');
+      expect(body.content).not.toContain('srcset=');
+      expect(body.content).not.toContain('sizes=');
       expect(body.content).not.toContain('![[promo-note]]');
       expect(body.content).not.toContain('Promo Note');
     });

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -1,12 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { replaceLocalImagesWithThumbnails, pushToWordPress, restoreLocalImagePath, htmlToMarkdown, pullFromWordPress } from './wordpress';
+import { pushToWordPress, restoreLocalImagePath, htmlToMarkdown, pullFromWordPress } from './wordpress';
 import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
-
-// Mock dependency modules
-vi.mock('./files', () => ({
-  getAssetSubDir: vi.fn(),
-}));
 
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
@@ -19,8 +14,6 @@ vi.mock('fs/promises', () => ({
   mkdir: vi.fn(),
 }));
 
-// Access mocked functions
-import { getAssetSubDir } from './files';
 import { readFile, readdir, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 
@@ -51,109 +44,8 @@ describe('WordPress Deployment Library', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default mock implementation
-    vi.mocked(getAssetSubDir).mockResolvedValue('content');
     vi.mocked(readFile).mockResolvedValue('# My Post Title\nThis is content.');
     global.fetch = vi.fn();
-  });
-
-  describe('replaceLocalImagesWithThumbnails', () => {
-    it('should replace local image sources with absolute CDN URLs pointing to the largest thumbnail', async () => {
-      const html = '<p>Hello world</p><img src="/images/pic.png" alt="Pic" />';
-      const sizes = [300, 600, 1200];
-
-      // Simulate that the file exists in the "content" directory
-      vi.mocked(getAssetSubDir).mockResolvedValue('content');
-
-      const result = await replaceLocalImagesWithThumbnails({
-        html,
-        site: mockSite,
-        registry: mockRegistry,
-        sizes,
-      });
-
-      expect(result).toContain(
-        '<img decoding="async" loading="lazy" style="max-width:100%;" sizes="(max-width: 1200px) 100vw, 1200px" srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp 1200w" src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp" alt="Pic" />'
-      );
-    });
-
-    it('should fallback to site domain if imageHost is not provided', async () => {
-      const html = '<img src="/pic.png" alt="Direct" />';
-      const sizes = [300, 600, 1200];
-
-      const siteWithoutImageHost = { ...mockSite, imageHost: undefined };
-
-      const result = await replaceLocalImagesWithThumbnails({
-        html,
-        site: siteWithoutImageHost,
-        registry: { ...mockRegistry, imageHost: undefined },
-        sizes,
-      });
-
-      expect(result).toContain(
-        '<img decoding="async" loading="lazy" style="max-width:100%;" sizes="(max-width: 1200px) 100vw, 1200px" srcset="https://testsite.com/api/vault-public/_thumbnails/pic-300.webp 300w, https://testsite.com/api/vault-public/_thumbnails/pic-600.webp 600w, https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp 1200w" src="https://testsite.com/api/vault-public/_thumbnails/pic-1200.webp" alt="Direct" />'
-      );
-    });
-
-    it('should preserve original image attributes like class, width, height', async () => {
-      const html = '<img src="/images/pic.png" class="aligncenter custom-class" width="800" height="600" alt="Pic" />';
-      const sizes = [300, 600, 1200];
-
-      vi.mocked(getAssetSubDir).mockResolvedValue('content');
-
-      const result = await replaceLocalImagesWithThumbnails({
-        html,
-        site: mockSite,
-        registry: mockRegistry,
-        sizes,
-      });
-
-      expect(result).toContain('class="aligncenter custom-class"');
-      expect(result).toContain('width="800"');
-      expect(result).toContain('height="600"');
-      expect(result).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/images/pic-1200.webp"');
-    });
-
-    it('should resolve encoded root-level image references to attachment thumbnails without double encoding', async () => {
-      const html = '<img src="/Pasted%2520image%252020260630150256.png" alt="Cable status" />';
-      const sizes = [300, 600, 1200];
-
-      const result = await replaceLocalImagesWithThumbnails({
-        html,
-        site: mockSite,
-        registry: mockRegistry,
-        sizes,
-        assetFiles: ['attachments/Pasted image 20260630150256.png'],
-      });
-
-      expect(result).toContain(
-        'src="https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-1200.webp"'
-      );
-      expect(result).toContain(
-        'srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/attachments/Pasted%20image%2020260630150256-1200.webp 1200w"'
-      );
-      expect(result).not.toContain('%2520');
-    });
-
-    it('should ignore external URLs and data URIs', async () => {
-      const html = `
-        <img src="https://external.com/photo.jpg" alt="Ext" />
-        <img src="data:image/png;base64,abc" alt="Data" />
-        <img src="#hash" alt="Hash" />
-      `;
-      const sizes = [300, 600, 1200];
-
-      const result = await replaceLocalImagesWithThumbnails({
-        html,
-        site: mockSite,
-        registry: mockRegistry,
-        sizes,
-      });
-
-      expect(result).toContain('src="https://external.com/photo.jpg"');
-      expect(result).toContain('src="data:image/png;base64,abc"');
-      expect(result).toContain('src="#hash"');
-    });
   });
 
   describe('htmlToMarkdown', () => {
@@ -367,6 +259,8 @@ describe('WordPress Deployment Library', () => {
             '',
             'Before embed.',
             '',
+            '![Hero](hero.png)',
+            '',
             '![[promo-note]]',
           ].join('\n');
         }
@@ -408,8 +302,22 @@ describe('WordPress Deployment Library', () => {
       const body = JSON.parse(postCall![1].body);
 
       expect(body.content).toContain('Embedded promotion body.');
+      expect(body.content).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp"');
+      expect(body.content).toContain('srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp 1200w"');
       expect(body.content).not.toContain('![[promo-note]]');
       expect(body.content).not.toContain('Promo Note');
+    });
+
+    it('should require imageHost for WordPress publishing', async () => {
+      await expect(
+        pushToWordPress({
+          site: { ...mockSite, imageHost: undefined },
+          registry: { ...mockRegistry, imageHost: undefined },
+          allIndices: mockIndices,
+          targetPostSlug: 'post-one',
+          dryRun: false,
+        })
+      ).rejects.toThrow('imageHost');
     });
 
     it('should only query and perform no mutations when dryRun is true', async () => {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -222,6 +222,62 @@ describe('WordPress Deployment Library', () => {
       expect(body.content).toContain('<!-- /wp:table -->');
     });
 
+    it('should publish markdown images as valid WordPress image blocks', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 789 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+      vi.mocked(readFile).mockImplementation(async (filePath) => {
+        const normalizedPath = String(filePath);
+        if (normalizedPath.endsWith('root.json')) {
+          return JSON.stringify({
+            publicFiles: [],
+            contentFiles: ['hero.png'],
+          });
+        }
+        return [
+          '# My Post Title',
+          '',
+          '![Hero caption](hero.png)',
+        ].join('\n');
+      });
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetPostSlug: 'post-one',
+        dryRun: false,
+      });
+
+      const postCall = mockFetch.mock.calls.find((call) => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body);
+      expect(body.content).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
+      expect(body.content).toContain('<figure class="size-large wp-block-image">');
+      expect(body.content).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp"');
+      expect(body.content).toContain('srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp 1200w"');
+      expect(body.content).toContain('sizes="(max-width: 1200px) 100vw, 1200px"');
+      expect(body.content).toContain('style="max-width: 100%;"');
+      expect(body.content).toContain('loading="lazy"');
+      expect(body.content).toContain('decoding="async"');
+      expect(body.content).toContain('<figcaption class="wp-element-caption">Hero caption</figcaption>');
+      expect(body.content).toContain('<!-- /wp:image -->');
+      expect(body.content).not.toContain('className":"wp-block-image');
+    });
+
     it('should transclude private note includes before publishing to WordPress', async () => {
       const mockFetch = vi.fn().mockImplementation(async (url, options) => {
         if (url.includes('/wp/v2/posts') && options.method === 'GET') {
@@ -302,8 +358,11 @@ describe('WordPress Deployment Library', () => {
       const body = JSON.parse(postCall![1].body);
 
       expect(body.content).toContain('Embedded promotion body.');
+      expect(body.content).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
+      expect(body.content).toContain('<figure class="size-large wp-block-image">');
       expect(body.content).toContain('src="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp"');
       expect(body.content).toContain('srcset="https://cdn.testsite.com/test-blog/content/_thumbnails/hero-300.webp 300w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-600.webp 600w, https://cdn.testsite.com/test-blog/content/_thumbnails/hero-1200.webp 1200w"');
+      expect(body.content).toContain('sizes="(max-width: 1200px) 100vw, 1200px"');
       expect(body.content).not.toContain('![[promo-note]]');
       expect(body.content).not.toContain('Promo Note');
     });

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -24,6 +24,11 @@ import { getAssetSubDir } from './files';
 import { readFile, readdir, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 
+type MockDirectoryEntry = {
+  name: string;
+  isDirectory: () => boolean;
+  isFile: () => boolean;
+};
 
 describe('WordPress Deployment Library', () => {
   const mockSite: Site = {
@@ -148,6 +153,27 @@ describe('WordPress Deployment Library', () => {
       expect(result).toContain('src="https://external.com/photo.jpg"');
       expect(result).toContain('src="data:image/png;base64,abc"');
       expect(result).toContain('src="#hash"');
+    });
+  });
+
+  describe('htmlToMarkdown', () => {
+    it('decodes collected WordPress media filenames for local Markdown references and downloads', () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      const collectedImages: { remoteUrl: string; tryHighResUrl: string; localPath: string }[] = [];
+
+      const result = htmlToMarkdown(
+        '<figure><img src="https://testsite.com/wp-content/uploads/2020/02/%E6%88%AA%E5%9C%96-2020-02-13-%E4%B8%8A%E5%8D%8810.36.11-1024x521.png" alt="" /></figure>',
+        mockSite,
+        mockRegistry,
+        'zelda-map',
+        collectedImages
+      );
+
+      expect(result).toContain('![](zelda-map/截圖-2020-02-13-上午10.36.11.png)');
+      expect(collectedImages[0]?.localPath).toBe('/mock/vault/content/zelda-map/截圖-2020-02-13-上午10.36.11.png');
+      expect(collectedImages[0]?.tryHighResUrl).toBe(
+        'https://testsite.com/wp-content/uploads/2020/02/截圖-2020-02-13-上午10.36.11.png'
+      );
     });
   });
 
@@ -302,6 +328,88 @@ describe('WordPress Deployment Library', () => {
       expect(body.content).toContain('<table class="has-fixed-layout">');
       expect(body.content).toContain('</table>\n</figure>');
       expect(body.content).toContain('<!-- /wp:table -->');
+    });
+
+    it('should transclude private note includes before publishing to WordPress', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 789 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+      const mockedReaddir = vi.mocked(readdir) as unknown as {
+        mockImplementation: (implementation: () => Promise<MockDirectoryEntry[]>) => void;
+      };
+      mockedReaddir.mockImplementation(async () => [
+        {
+          name: 'promo-note.md',
+          isDirectory: () => false,
+          isFile: () => true,
+        },
+      ]);
+      vi.mocked(readFile).mockImplementation(async (filePath) => {
+        if (filePath === '/mock/vault/content/post-one.md') {
+          return [
+            '---',
+            'title: "Post One"',
+            '---',
+            '# Post One',
+            '',
+            'Before embed.',
+            '',
+            '![[promo-note]]',
+          ].join('\n');
+        }
+        if (filePath === '/mock/vault/_includes/promo-note.md') {
+          return [
+            '---',
+            'title: "Promo Note"',
+            '---',
+            '# Promo Note',
+            '',
+            'Embedded promotion body.',
+          ].join('\n');
+        }
+        return '';
+      });
+
+      const indicesWithEmbed = new Map<string, VaultDirectoryIndex>([
+        [
+          '',
+          {
+            version: 1,
+            pages: [
+              { title: 'Post One', slug: 'post-one', date: '2026-06-16T12:00:00.000Z', excerpt: '' },
+            ],
+          },
+        ],
+      ]);
+
+      await pushToWordPress({
+        site: { ...mockSite, noteIncludePaths: ['_includes'] },
+        registry: mockRegistry,
+        allIndices: indicesWithEmbed,
+        targetPostSlug: 'post-one',
+        dryRun: false,
+      });
+
+      const postCall = mockFetch.mock.calls.find((call) => call[1]?.method === 'POST');
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall![1].body);
+
+      expect(body.content).toContain('Embedded promotion body.');
+      expect(body.content).not.toContain('![[promo-note]]');
+      expect(body.content).not.toContain('Promo Note');
     });
 
     it('should only query and perform no mutations when dryRun is true', async () => {
@@ -538,6 +646,11 @@ describe('WordPress Deployment Library', () => {
       expect(writeFile).toHaveBeenCalledWith(
         '/mock/vault/content/post-one.md',
         expect.stringContaining('title: "Post One Title"'),
+        'utf-8'
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        '/mock/vault/content/post-one.md',
+        expect.not.stringContaining('---\n\n# Post One Title'),
         'utf-8'
       );
       expect(writeFile).toHaveBeenCalledWith(

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -8,7 +8,9 @@ import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
 import { serializeHtmlToWordPressBlocks } from '../../src/lib/wordpress-blocks';
 import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl, RESPONSIVE_IMAGE_SIZES } from '../../src/lib/responsive-images';
-import { isExternalOrInlineAsset, resolveLocalImagePath } from '../../src/lib/local-images';
+import { isExternalOrInlineAsset, resolveLocalImagePath, safelyDecodeUriComponent } from '../../src/lib/local-images';
+import { type NoteReferenceInput } from '../../src/lib/note-links';
+import { collectNoteReferencesForLocalMarkdown, collectPrivateNoteIncludes } from './note-includes';
 
 
 interface PushToWordPressArgs {
@@ -25,6 +27,41 @@ interface WpFetchArgs {
   path: string;
   method?: string;
   body?: unknown;
+}
+
+function buildNoteReferenceInputs({ allIndices }: { allIndices: Map<string, VaultDirectoryIndex> }): NoteReferenceInput[] {
+  const noteReferences: NoteReferenceInput[] = [];
+  for (const [dirKey, dirIndex] of allIndices.entries()) {
+    for (const page of dirIndex.pages) {
+      noteReferences.push({
+        fullSlug: dirKey ? `${dirKey}/${page.slug}` : page.slug,
+        title: page.title,
+      });
+    }
+  }
+  return noteReferences;
+}
+
+async function collectLocalNoteReferences({
+  site,
+  allIndices,
+  markdown,
+}: {
+  site: Site;
+  allIndices: Map<string, VaultDirectoryIndex>;
+  markdown: string;
+}) {
+  const privateNoteReferences = await collectPrivateNoteIncludes({
+    vaultPath: site.vaultPath,
+    includePaths: site.noteIncludePaths,
+  });
+
+  return collectNoteReferencesForLocalMarkdown({
+    publicNoteReferences: buildNoteReferenceInputs({ allIndices }),
+    privateNoteReferences,
+    markdown,
+    readPublicNote: ({ fullSlug }) => readFile(path.join(site.vaultPath, 'content', `${fullSlug}.md`), 'utf-8'),
+  });
 }
 
 /**
@@ -283,12 +320,18 @@ export async function pushToWordPress({
         }
       }
       const bodyWithoutTitle = lines.join('\n').trim();
+      const noteReferences = await collectLocalNoteReferences({
+        site,
+        allIndices,
+        markdown: bodyWithoutTitle,
+      });
 
       // Render Markdown content to HTML
       let htmlContent = await renderMarkdownContent({
         markdown: bodyWithoutTitle,
         thumbnailSizes: sizes,
         assetFiles,
+        noteReferences,
         getFigureProperties: (largestWidth) => {
           return {
             class: 'wp-block-image',
@@ -492,7 +535,7 @@ export function resolveAndCollectImagePath(
   const ext = path.extname(filename);
   const baseName = path.basename(filename, ext);
   const cleanBaseName = baseName.replace(/-(\d+x\d+|\d+)$/, '');
-  const finalFilename = `${cleanBaseName}${ext}`;
+  const finalFilename = safelyDecodeUriComponent({ value: `${cleanBaseName}${ext}` });
 
   // Check if the file already exists locally
   const dir = path.dirname(tempPath);
@@ -866,7 +909,6 @@ export async function pullFromWordPress({
     `date: "${dateIso}"`,
     `updated: "${modifiedIso}"`,
     `---`,
-    ``,
     `# ${decodedTitle}`,
     ``,
     markdownBody,

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -2,13 +2,12 @@ import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
-import { getAssetSubDir } from './files';
 import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
 import { serializeHtmlToWordPressBlocks } from '../../src/lib/wordpress-blocks';
-import { getThumbnailPath, normalizeThumbnailSizes, getAssetUrl, RESPONSIVE_IMAGE_SIZES } from '../../src/lib/responsive-images';
-import { isExternalOrInlineAsset, resolveLocalImagePath, safelyDecodeUriComponent } from '../../src/lib/local-images';
+import { normalizeThumbnailSizes } from '../../src/lib/responsive-images';
+import { safelyDecodeUriComponent } from '../../src/lib/local-images';
 import { type NoteReferenceInput } from '../../src/lib/note-links';
 import { collectNoteReferencesForLocalMarkdown, collectPrivateNoteIncludes } from './note-includes';
 
@@ -100,131 +99,6 @@ async function wpFetch({
 }
 
 /**
- * Parses HTML and replaces all local image source references with their absolute 
- * URL on the designated image host, utilizing the largest generated thumbnail size.
- */
-export async function replaceLocalImagesWithThumbnails({
-  html,
-  site,
-  registry,
-  sizes,
-  assetFiles,
-}: {
-  html: string;
-  site: Site;
-  registry: Registry;
-  sizes: readonly number[];
-  assetFiles?: readonly string[];
-}): Promise<string> {
-  const imageHost = site.imageHost || registry.imageHost;
-  const largestWidth = sizes[sizes.length - 1];
-
-  if (!largestWidth) {
-    return html;
-  }
-
-  let processedHtml = html;
-
-  // Process HTML <img> tags
-  const imgRegex = /<img\s+([^>]*src=["']([^"']+)["'][^>]*?)>/gi;
-  const matches: { fullMatch: string; src: string }[] = [];
-  let match;
-  while ((match = imgRegex.exec(processedHtml)) !== null) {
-    matches.push({ fullMatch: match[0], src: match[2] });
-  }
-
-  // Deduplicate matches to avoid redundant checks/replacements
-  const uniqueMatches = Array.from(
-    new Map(matches.map((m) => [m.fullMatch, m])).values()
-  );
-
-  for (const { fullMatch, src } of uniqueMatches) {
-    // Skip external or inline assets
-    if (isExternalOrInlineAsset({ src })) {
-      continue;
-    }
-
-    const imagePath = resolveLocalImagePath({ src, availableFiles: assetFiles });
-
-    // Get the thumbnail filename and relative directory path
-    const thumbPath = getThumbnailPath({ imagePath, width: largestWidth });
-
-    // Determine target location in S3 by checking local filesystem existence
-    const s3SubDir = await getAssetSubDir({ vaultPath: site.vaultPath, filePath: thumbPath });
-
-    // Build the absolute URL on the configured imageHost
-    const absoluteUrl = getAssetUrl({
-      imageHost,
-      siteId: site.siteId,
-      s3SubDir,
-      filePath: thumbPath,
-      domain: site.domain,
-    });
-
-    // Build the srcset attributes for all defined thumbnail sizes
-    const srcSetUrls = sizes.map((size) => {
-      const sizeThumbPath = getThumbnailPath({ imagePath, width: size });
-      const sizeUrl = getAssetUrl({
-        imageHost,
-        siteId: site.siteId,
-        s3SubDir,
-        filePath: sizeThumbPath,
-        domain: site.domain,
-      });
-      return `${encodeURI(sizeUrl)} ${size}w`;
-    }).join(', ');
-
-    let newImgTag = fullMatch;
-    
-    // Replace src in-place
-    newImgTag = newImgTag.replace(/src=["']([^"']*)["']/i, `src="${encodeURI(absoluteUrl)}"`);
-
-    // Inject/replace srcset and sizes in-place
-    if (srcSetUrls) {
-      newImgTag = setAttribute(newImgTag, 'srcset', srcSetUrls);
-      newImgTag = setAttribute(newImgTag, 'sizes', `(max-width: ${largestWidth}px) 100vw, ${largestWidth}px`);
-    }
-
-    // Append/merge style style="max-width: 100%;"
-    if (/style=["']/i.test(newImgTag)) {
-      newImgTag = newImgTag.replace(/style=["']([^"']*)["']/i, (m, p1) => {
-        const trimmed = p1.trim();
-        const separator = trimmed.endsWith(';') || trimmed === '' ? '' : ';';
-        return `style="${p1}${separator}max-width:100%;"`;
-      });
-    } else {
-      newImgTag = newImgTag.replace(/(<img\b)/i, '$1 style="max-width:100%;"');
-    }
-
-    // Append loading="lazy" if not present
-    if (!/loading=["']/i.test(newImgTag)) {
-      newImgTag = newImgTag.replace(/(<img\b)/i, '$1 loading="lazy"');
-    }
-
-    // Append decoding="async" if not present
-    if (!/decoding=["']/i.test(newImgTag)) {
-      newImgTag = newImgTag.replace(/(<img\b)/i, '$1 decoding="async"');
-    }
-
-    processedHtml = processedHtml.replaceAll(fullMatch, newImgTag);
-  }
-
-  return processedHtml;
-}
-
-/**
- * Helper to inject or update an attribute inside an HTML tag.
- * Inserts the attribute right after '<img' to ensure self-closing tags are not broken.
- */
-function setAttribute(tag: string, name: string, value: string): string {
-  const regex = new RegExp(`${name}=["']([^"']*)["']`, 'i');
-  if (regex.test(tag)) {
-    return tag.replace(regex, `${name}="${value}"`);
-  }
-  return tag.replace(/(<img\b)/i, `$1 ${name}="${value}"`);
-}
-
-/**
  * Iterates through the Markdown posts in the vault and publishes them to WordPress.
  */
 export async function pushToWordPress({
@@ -241,6 +115,11 @@ export async function pushToWordPress({
 
   const endpoint = credentials.endpoint || `https://${site.domain}/wp-json`;
   const sizes = normalizeThumbnailSizes(site.thumbnailSizes || registry.thumbnailSizes);
+  const imageHost = site.imageHost || registry.imageHost;
+
+  if (!imageHost) {
+    throw new Error(`⨯ WordPress publishing requires "imageHost" for externally reachable thumbnail URLs.`);
+  }
 
   console.log(`\n📝 Preparing WordPress Publishing...`);
   console.log(`- Target Endpoint: ${endpoint}`);
@@ -332,6 +211,12 @@ export async function pushToWordPress({
         thumbnailSizes: sizes,
         assetFiles,
         noteReferences,
+        assetUrlConfig: {
+          imageHost,
+          siteId: site.siteId,
+          s3SubDir: 'content',
+          mode: 'absolute',
+        },
         getFigureProperties: (largestWidth) => {
           return {
             class: 'wp-block-image',
@@ -345,14 +230,6 @@ export async function pushToWordPress({
         },
       });
 
-      // Replace local image paths with imageHost absolute thumbnail URLs
-      htmlContent = await replaceLocalImagesWithThumbnails({
-        html: htmlContent,
-        site,
-        registry,
-        sizes,
-        assetFiles,
-      });
       const wordpressBlockContent = serializeHtmlToWordPressBlocks(htmlContent);
 
       // Replace slashes with hyphens to match WordPress's sanitization behavior

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { resolveVaultRequest, fetchRootIndex } from "@/lib/vault";
+import { resolveVaultRequest, fetchRootIndex, fetchNoteReferencesForMarkdown } from "@/lib/vault";
 import { env } from "@/lib/env";
 import { INDEX_SLUG } from "@/lib/constants";
 import { renderMarkdownContent } from "@/lib/markdown";
@@ -63,19 +63,30 @@ export default async function DynamicPage({ params }: { params: Promise<{ slug?:
 
   // 1. Render matched Markdown file
   if (result.type === "markdown") {
-    const { content: markdownBody } = matter(result.content);
+    const { content: markdownBody } = result.renderedHtml ? { content: "" } : matter(result.content);
 
     // Strip the first H1 from the body if it exists, to avoid double titles
-    const bodyWithoutTitle = markdownBody.replace(/^#\s+.+$/m, "").trim();
+    const bodyWithoutTitle = result.renderedHtml ? "" : markdownBody.replace(/^#\s+.+$/m, "").trim();
 
-    const rootIndex = await fetchRootIndex(vaultConfig);
+    const rootIndex = result.renderedHtml ? null : await fetchRootIndex(vaultConfig);
     const assetFiles = rootIndex?.assetFiles || rootIndex?.publicFiles || [];
+    const noteReferences =
+      !result.renderedHtml && rootIndex
+        ? await fetchNoteReferencesForMarkdown({
+            config: vaultConfig,
+            markdown: bodyWithoutTitle,
+            rootIndex,
+          })
+        : [];
 
-    const contentHtml = await renderMarkdownContent({
-      markdown: bodyWithoutTitle,
-      thumbnailSizes: result.thumbnailSizes,
-      assetFiles,
-    });
+    const contentHtml =
+      result.renderedHtml ||
+      (await renderMarkdownContent({
+        markdown: bodyWithoutTitle,
+        thumbnailSizes: result.thumbnailSizes,
+        assetFiles,
+        noteReferences,
+      }));
     const { metadata } = result;
 
     const publishedDate = new Date(metadata.date);

--- a/src/domain/registry.ts
+++ b/src/domain/registry.ts
@@ -12,6 +12,7 @@ export const SiteSchema = z.object({
   domain: z.string().optional(),
   siteId: z.string(),
   vaultPath: z.string(),
+  noteIncludePaths: z.array(z.string()).optional(),
   bucketName: z.string().optional(),
   vercelProjectId: z.string().optional(),
   endpoint: z.string().url().optional(),
@@ -31,4 +32,3 @@ export const RegistrySchema = z.object({
 
 export type Site = z.infer<typeof SiteSchema>;
 export type Registry = z.infer<typeof RegistrySchema>;
-

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -38,6 +38,11 @@ export const DEFAULT_REGISTRY_FILENAME = 'registry.json';
 export const THUMBNAILS_DIR = '_thumbnails';
 
 /**
+ * Generated rendered HTML artifact directory.
+ */
+export const RENDERED_DIR = '_rendered';
+
+/**
  * Default responsive image widths, in pixels.
  */
 export const DEFAULT_THUMBNAIL_SIZES = [320, 640, 960, 1280] as const;

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -42,7 +42,7 @@ describe("createMarkdownRenderer", () => {
       assetFiles: ["image.png"],
     });
     expect(html).toContain('<figure class="image-figure">');
-    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
+    expect(html).toContain('<img src="/api/vault-public/_thumbnails/image-320.webp" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
   });
 
@@ -54,8 +54,8 @@ describe("createMarkdownRenderer", () => {
       assetFiles: ["attachments/Pasted image 20260630150256.png"],
     });
 
-    expect(html).toContain('src="/attachments/Pasted%20image%2020260630150256.png"');
-    expect(html).toContain('srcset="/_thumbnails/attachments/Pasted%20image%2020260630150256-320.webp 320w"');
+    expect(html).toContain('src="/api/vault-public/_thumbnails/attachments/Pasted%20image%2020260630150256-320.webp"');
+    expect(html).toContain('srcset="/api/vault-public/_thumbnails/attachments/Pasted%20image%2020260630150256-320.webp 320w"');
   });
 
   it("renders GitHub-Flavored Markdown tables inside generic figures", async () => {
@@ -148,7 +148,7 @@ describe("createMarkdownRenderer", () => {
     });
     expect(html).toContain("<p>Some text before</p>");
     expect(html).toContain('<figure class="image-figure">');
-    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
+    expect(html).toContain('<img src="/api/vault-public/_thumbnails/image-320.webp" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain("<p>Some text after</p>");
   });
 
@@ -160,7 +160,7 @@ describe("createMarkdownRenderer", () => {
       assetFiles: ["image.png"],
     });
     expect(html).toContain('<figure class="image-figure">');
-    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
+    expect(html).toContain('<img src="/api/vault-public/_thumbnails/image-320.webp" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain('<figcaption>My Alt Text</figcaption></figure>');
   });
 
@@ -172,7 +172,7 @@ describe("createMarkdownRenderer", () => {
       assetFiles: ["image.png"],
     });
     expect(html).toContain('<figure class="image-figure">');
-    expect(html).toContain('<img src="/image.png" style="max-width: 100%;" alt="My Alt Text"');
+    expect(html).toContain('<img src="/api/vault-public/_thumbnails/image-320.webp" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain('<figcaption>This is my <a href="https://example.com">caption link</a> text.</figcaption></figure>');
     expect(html).not.toContain('<p><em>This is my');
   });

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createMarkdownRenderer, type MarkdownNode, preprocessWikilinks } from "./markdown";
+import { serializeHtmlToWordPressBlocks } from "./wordpress-blocks";
 
 describe("createMarkdownRenderer", () => {
   it("injects responsive image attributes into image nodes before processing", async () => {
@@ -175,6 +176,28 @@ describe("createMarkdownRenderer", () => {
     expect(html).toContain('<img src="/api/vault-public/_thumbnails/image-320.webp" style="max-width: 100%;" alt="My Alt Text"');
     expect(html).toContain('<figcaption>This is my <a href="https://example.com">caption link</a> text.</figcaption></figure>');
     expect(html).not.toContain('<p><em>This is my');
+  });
+
+  it("renders markdown images and image wikilinks to the same cached HTML and WordPress image block", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const render = (markdown: string) => renderMarkdownContent({
+      markdown,
+      thumbnailSizes: [320],
+      assetFiles: ["attachments/map.png"],
+      getFigureProperties: () => ({ class: "wp-block-image", style: "height: auto !important;" }),
+    });
+
+    const markdownImageHtml = await render("![](attachments/map.png)\n*Map caption.*");
+    const wikilinkImageHtml = await render("![[map.png]]\n*Map caption.*");
+
+    expect(wikilinkImageHtml).toBe(markdownImageHtml);
+    expect(markdownImageHtml).toContain('srcset="/api/vault-public/_thumbnails/attachments/map-320.webp 320w"');
+
+    const markdownImageBlock = serializeHtmlToWordPressBlocks(markdownImageHtml);
+    const wikilinkImageBlock = serializeHtmlToWordPressBlocks(wikilinkImageHtml);
+    expect(wikilinkImageBlock).toBe(markdownImageBlock);
+    expect(markdownImageBlock).toContain('<img src="/api/vault-public/_thumbnails/attachments/map-320.webp" alt="" />');
+    expect(markdownImageBlock).not.toContain("srcset=");
   });
 });
 

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -209,6 +209,12 @@ describe("preprocessWikilinks", () => {
     expect(result).toBe("Hello ![](</attachments/screenshot.png>) and ![My Alt Text](</attachments/screenshot.png>)");
   });
 
+  it("converts path-prefixed image wikilinks using available asset files", () => {
+    const result = preprocessWikilinks("Map ![[attachments/map.png|Map Alt]]", ["attachments/map.png"]);
+
+    expect(result).toBe("Map ![Map Alt](</attachments/map.png>)");
+  });
+
   it("converts note wikilinks to Markdown links using note titles", () => {
     const result = preprocessWikilinks("Read [[vpn-promotion-for-games]].", [], [
       {

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -185,4 +185,88 @@ describe("preprocessWikilinks", () => {
     const result = preprocessWikilinks(markdown, assetFiles);
     expect(result).toBe("Hello ![](</attachments/screenshot.png>) and ![My Alt Text](</attachments/screenshot.png>)");
   });
+
+  it("converts note wikilinks to Markdown links using note titles", () => {
+    const result = preprocessWikilinks("Read [[vpn-promotion-for-games]].", [], [
+      {
+        fullSlug: "vpn-promotion-for-games",
+        title: "Best VPN Promotions for Games",
+        href: "/vpn-promotion-for-games",
+      },
+    ]);
+
+    expect(result).toBe("Read [Best VPN Promotions for Games](/vpn-promotion-for-games).");
+  });
+
+  it("keeps nested note paths when rendering wikilink URLs", () => {
+    const result = preprocessWikilinks("Read [[gaming/vpn-promotion-for-games]].", [], [
+      {
+        fullSlug: "gaming/vpn-promotion-for-games",
+        title: "Best VPN Promotions for Games",
+        href: "/gaming/vpn-promotion-for-games",
+      },
+    ]);
+
+    expect(result).toBe("Read [Best VPN Promotions for Games](/gaming/vpn-promotion-for-games).");
+  });
+
+  it("renders note embeds as content without adding the embedded note title", () => {
+    const result = preprocessWikilinks("Before\n![[vpn-promotion-for-games]]\nAfter", [], [
+      {
+        fullSlug: "vpn-promotion-for-games",
+        title: "Best VPN Promotions for Games",
+        href: "/vpn-promotion-for-games",
+        content: "This is the promotion body.",
+      },
+    ]);
+
+    expect(result).toBe("Before\n\n\nThis is the promotion body.\n\n\nAfter");
+  });
+
+  it("recursively renders note embeds and note links inside embedded note content", () => {
+    const result = preprocessWikilinks("Before\n![[first-embed]]\nAfter", [], [
+      {
+        fullSlug: "first-embed",
+        title: "First Embed",
+        href: "/first-embed",
+        content: "First body.\n\n![[second-embed]]\n\n[[linked-note]]",
+      },
+      {
+        fullSlug: "second-embed",
+        title: "Second Embed",
+        href: "/second-embed",
+        content: "Second body.",
+      },
+      {
+        fullSlug: "linked-note",
+        title: "Linked Note",
+        href: "/linked-note",
+      },
+    ]);
+
+    expect(result).toContain("Before");
+    expect(result).toContain("First body.");
+    expect(result).toContain("Second body.");
+    expect(result).toContain("[Linked Note](/linked-note)");
+    expect(result).toContain("After");
+    expect(result).not.toContain("[[");
+    expect(result.indexOf("First body.")).toBeLessThan(result.indexOf("Second body."));
+    expect(result.indexOf("Second body.")).toBeLessThan(result.indexOf("[Linked Note](/linked-note)"));
+  });
+
+  it("does not render private include notes as normal links", () => {
+    const result = preprocessWikilinks("Embed ![[promo-note]] but keep [[promo-note]].", [], [
+      {
+        fullSlug: "promo-note",
+        title: "Promo Note",
+        href: "/promo-note",
+        content: "Private promo body.",
+        linkable: false,
+      },
+    ]);
+
+    expect(result).toContain("Private promo body.");
+    expect(result).toContain("[[promo-note]]");
+    expect(result).not.toContain("[Promo Note](/promo-note)");
+  });
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -4,6 +4,7 @@ import gfm from "remark-gfm";
 import type { Plugin } from "unified";
 import { getResponsiveImageAttributes, normalizeThumbnailSizes } from "./responsive-images";
 import { resolveMarkdownImagePaths } from "./local-images";
+import { createNoteReferenceResolver, parseWikilinkContent, type NoteReference } from "./note-links";
 
 export type MarkdownNode = {
   type: "root" | "paragraph" | "image" | "image-figure" | "element" | "text" | "html" | (string & {});
@@ -265,6 +266,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       publicFiles,
       getFigureProperties,
       getTableFigureProperties,
+      noteReferences,
     }: {
       markdown: string;
       thumbnailSizes: readonly number[];
@@ -272,9 +274,10 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       publicFiles?: readonly string[];
       getFigureProperties?: (largestWidth: number) => FigureProperties;
       getTableFigureProperties?: () => FigureProperties;
+      noteReferences?: readonly NoteReference[];
     }): Promise<string> {
       const availableFiles = assetFiles || publicFiles;
-      let preprocessed = availableFiles ? preprocessWikilinks(markdown, availableFiles) : markdown;
+      let preprocessed = preprocessWikilinks(markdown, availableFiles || [], noteReferences);
       preprocessed = availableFiles ? resolveMarkdownImagePaths({ markdown: preprocessed, availableFiles }) : preprocessed;
       preprocessed = ensureImageBlockSeparation(preprocessed);
       return deps.processMarkdown({
@@ -285,32 +288,73 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
   };
 }
 
-export function preprocessWikilinks(markdown: string, availableFiles: readonly string[]): string {
-  const wikilinkRegex = /!\[\[([^\]]+)\]\]/g;
-  return markdown.replace(wikilinkRegex, (match, content) => {
-    const parts = content.split('|');
-    const filename = parts[0].trim();
-
-    let alt = '';
-    for (let i = 1; i < parts.length; i++) {
-      const part = parts[i].trim();
-      if (!/^\d+$/.test(part)) {
-        alt = part;
-      }
+export function preprocessWikilinks(
+  markdown: string,
+  availableFiles: readonly string[],
+  noteReferences: readonly NoteReference[] = []
+): string {
+  let preprocessed = markdown;
+  for (let pass = 0; pass < 10; pass += 1) {
+    const next = preprocessWikilinksOnce(preprocessed, availableFiles, noteReferences);
+    if (next === preprocessed) {
+      return next;
     }
+    preprocessed = next;
+  }
+  return preprocessed;
+}
 
-    const normalizedFilename = filename.toLowerCase();
+function preprocessWikilinksOnce(
+  markdown: string,
+  availableFiles: readonly string[],
+  noteReferences: readonly NoteReference[]
+): string {
+  const noteResolver = createNoteReferenceResolver({ notes: noteReferences });
+  const embedRegex = /!\[\[([^\]]+)\]\]/g;
+  const linkRegex = /(^|[^!])\[\[([^\]]+)\]\]/g;
+
+  const withEmbeds = markdown.replace(embedRegex, (match, content) => {
+    const { target } = parseWikilinkContent({ content });
+    const normalizedFilename = target.toLowerCase();
     const resolvedPath = availableFiles.find((file) => {
       const base = file.split('/').pop()?.toLowerCase();
       return base === normalizedFilename;
     });
 
     if (resolvedPath) {
+      const alt = getImageAltFromWikilinkContent({ content });
       return `![${alt}](</${resolvedPath}>)`;
+    }
+
+    const noteReference = noteResolver.resolve({ target });
+    if (noteReference?.content) {
+      return `\n\n${noteReference.content.trim()}\n\n`;
     }
 
     return match;
   });
+
+  return withEmbeds.replace(linkRegex, (match, prefix, content) => {
+    const { target, label } = parseWikilinkContent({ content });
+    const noteReference = noteResolver.resolve({ target });
+    if (!noteReference || noteReference.linkable === false) {
+      return match;
+    }
+
+    return `${prefix}[${label || noteReference.title}](${noteReference.href})`;
+  });
+}
+
+function getImageAltFromWikilinkContent({ content }: { content: string }): string {
+  const parts = content.split("|").slice(1);
+  let alt = "";
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      alt = trimmed;
+    }
+  }
+  return alt;
 }
 
 const defaultMarkdownRenderer = createMarkdownRenderer({

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -2,7 +2,7 @@ import { remark } from "remark";
 import html from "remark-html";
 import gfm from "remark-gfm";
 import type { Plugin } from "unified";
-import { getResponsiveImageAttributes, normalizeThumbnailSizes } from "./responsive-images";
+import { getResponsiveImageAttributes, normalizeThumbnailSizes, type AssetUrlConfig } from "./responsive-images";
 import { resolveMarkdownImagePaths } from "./local-images";
 import { createNoteReferenceResolver, parseWikilinkContent, type NoteReference } from "./note-links";
 
@@ -26,9 +26,11 @@ export type MarkdownRendererDeps = {
   getResponsiveImageAttributes: ({
     src,
     thumbnailSizes,
+    assetUrlConfig,
   }: {
     src: string;
     thumbnailSizes: readonly number[];
+    assetUrlConfig?: AssetUrlConfig;
   }) => { src: string; srcSet: string; sizes: string } | null;
   processMarkdown: ({ markdown, plugin }: { markdown: string; plugin: Plugin<[], MarkdownNode> }) => Promise<string>;
 };
@@ -87,10 +89,12 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
     tree,
     thumbnailSizes,
     getFigureProperties,
+    assetUrlConfig,
   }: {
     tree: MarkdownNode;
     thumbnailSizes: readonly number[];
     getFigureProperties?: (largestWidth: number) => FigureProperties;
+    assetUrlConfig?: AssetUrlConfig;
   }) {
     const normalizedSizes = normalizeThumbnailSizes(thumbnailSizes);
     const largestWidth = normalizedSizes[normalizedSizes.length - 1] || 768;
@@ -109,7 +113,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
           if (child.type === "paragraph" && nonWhitespaceChildren.length === 1 && nonWhitespaceChildren[0].type === "image") {
             const imgNode = nonWhitespaceChildren[0];
             const imgUrl = imgNode.url || "";
-            const attributes = deps.getResponsiveImageAttributes({ src: imgUrl, thumbnailSizes });
+            const attributes = deps.getResponsiveImageAttributes({ src: imgUrl, thumbnailSizes, assetUrlConfig });
             const srcVal = attributes ? attributes.src : encodeURI(imgUrl);
             const altText = imgNode.alt || '';
 
@@ -221,7 +225,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       }
 
       if (node.type === "image" && node.url) {
-        const attributes = deps.getResponsiveImageAttributes({ src: node.url, thumbnailSizes });
+        const attributes = deps.getResponsiveImageAttributes({ src: node.url, thumbnailSizes, assetUrlConfig });
         if (attributes) {
           node.data = {
             ...node.data,
@@ -245,13 +249,15 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
   function responsiveImagePlugin({
     thumbnailSizes,
     getFigureProperties,
+    assetUrlConfig,
   }: {
     thumbnailSizes: readonly number[];
     getFigureProperties?: (largestWidth: number) => FigureProperties;
+    assetUrlConfig?: AssetUrlConfig;
   }): Plugin<[], MarkdownNode> {
     return function transformResponsiveImages() {
       return function transformer(tree: MarkdownNode) {
-        applyResponsiveImages({ tree, thumbnailSizes, getFigureProperties });
+        applyResponsiveImages({ tree, thumbnailSizes, getFigureProperties, assetUrlConfig });
       };
     };
   }
@@ -267,6 +273,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       getFigureProperties,
       getTableFigureProperties,
       noteReferences,
+      assetUrlConfig,
     }: {
       markdown: string;
       thumbnailSizes: readonly number[];
@@ -275,6 +282,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       getFigureProperties?: (largestWidth: number) => FigureProperties;
       getTableFigureProperties?: () => FigureProperties;
       noteReferences?: readonly NoteReference[];
+      assetUrlConfig?: AssetUrlConfig;
     }): Promise<string> {
       const availableFiles = assetFiles || publicFiles;
       let preprocessed = preprocessWikilinks(markdown, availableFiles || [], noteReferences);
@@ -282,7 +290,7 @@ export function createMarkdownRenderer(deps: MarkdownRendererDeps) {
       preprocessed = ensureImageBlockSeparation(preprocessed);
       return deps.processMarkdown({
         markdown: preprocessed,
-        plugin: responsiveImagePlugin({ thumbnailSizes, getFigureProperties }),
+        plugin: responsiveImagePlugin({ thumbnailSizes, getFigureProperties, assetUrlConfig }),
       }).then((htmlContent) => wrapTablesInFigures(htmlContent, getTableFigureProperties));
     },
   };

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -325,8 +325,9 @@ function preprocessWikilinksOnce(
     const { target } = parseWikilinkContent({ content });
     const normalizedFilename = target.toLowerCase();
     const resolvedPath = availableFiles.find((file) => {
+      const normalizedFile = file.toLowerCase();
       const base = file.split('/').pop()?.toLowerCase();
-      return base === normalizedFilename;
+      return normalizedFile === normalizedFilename || normalizedFile.endsWith(`/${normalizedFilename}`) || base === normalizedFilename;
     });
 
     if (resolvedPath) {

--- a/src/lib/note-links.test.ts
+++ b/src/lib/note-links.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createNoteReferenceResolver, extractWikilinkTargets, getNoteHref } from "./note-links";
+
+describe("note link helpers", () => {
+  it("maps page slugs to route hrefs", () => {
+    expect(getNoteHref({ fullSlug: "page" })).toBe("/");
+    expect(getNoteHref({ fullSlug: "guides/page" })).toBe("/guides");
+    expect(getNoteHref({ fullSlug: "guides/vpn-promotion-for-games" })).toBe("/guides/vpn-promotion-for-games");
+  });
+
+  it("resolves unique leaf slugs to their nested full paths", () => {
+    const resolver = createNoteReferenceResolver({
+      notes: [
+        {
+          fullSlug: "guides/vpn-promotion-for-games",
+          title: "Best VPN Promotions for Games",
+        },
+      ],
+    });
+
+    expect(resolver.resolve({ target: "vpn-promotion-for-games" })?.href).toBe("/guides/vpn-promotion-for-games");
+  });
+
+  it("leaves ambiguous leaf slugs unresolved", () => {
+    const resolver = createNoteReferenceResolver({
+      notes: [
+        { fullSlug: "games/vpn", title: "Gaming VPN" },
+        { fullSlug: "privacy/vpn", title: "Privacy VPN" },
+      ],
+    });
+
+    expect(resolver.resolve({ target: "vpn" })).toBeNull();
+  });
+
+  it("extracts note link and embed targets separately", () => {
+    expect(extractWikilinkTargets("Read [[vpn]] and embed ![[promo-card]].")).toEqual({
+      links: ["vpn"],
+      embeds: ["promo-card"],
+    });
+  });
+});

--- a/src/lib/note-links.ts
+++ b/src/lib/note-links.ts
@@ -1,0 +1,118 @@
+import { INDEX_SLUG } from "./constants";
+
+export type NoteReference = {
+  fullSlug: string;
+  title: string;
+  href: string;
+  content?: string;
+  linkable?: boolean;
+};
+
+export type NoteReferenceInput = {
+  fullSlug: string;
+  title: string;
+  content?: string;
+  linkable?: boolean;
+};
+
+export type WikilinkTargets = {
+  links: readonly string[];
+  embeds: readonly string[];
+};
+
+function normalizeNoteTarget(target: string): string {
+  const trimmed = target.trim().replace(/^\//, "").replace(/\.md$/i, "");
+  const headingIndex = trimmed.indexOf("#");
+  return headingIndex === -1 ? trimmed : trimmed.slice(0, headingIndex);
+}
+
+function getLeafSlug(fullSlug: string): string {
+  const parts = fullSlug.split("/");
+  return parts[parts.length - 1] || fullSlug;
+}
+
+export function getNoteHref({ fullSlug }: { fullSlug: string }): string {
+  if (fullSlug === INDEX_SLUG) {
+    return "/";
+  }
+
+  const segments = fullSlug.split("/");
+  const lastSegment = segments[segments.length - 1];
+  const urlSegments = lastSegment === INDEX_SLUG ? segments.slice(0, -1) : segments;
+  const urlPath = urlSegments.map((segment) => encodeURIComponent(segment)).join("/");
+  return `/${urlPath}`;
+}
+
+export function extractWikilinkTargets(markdown: string): WikilinkTargets {
+  const links = new Set<string>();
+  const embeds = new Set<string>();
+  const embedRegex = /!\[\[([^\]]+)\]\]/g;
+  const linkRegex = /(^|[^!])\[\[([^\]]+)\]\]/g;
+
+  let embedMatch: RegExpExecArray | null;
+  while ((embedMatch = embedRegex.exec(markdown)) !== null) {
+    const target = parseWikilinkContent({ content: embedMatch[1] }).target;
+    if (target) {
+      embeds.add(target);
+    }
+  }
+
+  let linkMatch: RegExpExecArray | null;
+  while ((linkMatch = linkRegex.exec(markdown)) !== null) {
+    const target = parseWikilinkContent({ content: linkMatch[2] }).target;
+    if (target) {
+      links.add(target);
+    }
+  }
+
+  return {
+    links: [...links],
+    embeds: [...embeds],
+  };
+}
+
+export function parseWikilinkContent({ content }: { content: string }): { target: string; label?: string } {
+  const [rawTarget, ...labelParts] = content.split("|");
+  const target = normalizeNoteTarget(rawTarget || "");
+  const label = labelParts.join("|").trim();
+  return label ? { target, label } : { target };
+}
+
+export function createNoteReferenceResolver({ notes }: { notes: readonly NoteReferenceInput[] }) {
+  const references = notes.map((note) => ({
+    ...note,
+    href: getNoteHref({ fullSlug: note.fullSlug }),
+  }));
+  const referencesByKey = new Map<string, NoteReference>();
+  const referencesByLeaf = new Map<string, NoteReference[]>();
+
+  for (const reference of references) {
+    const keys = new Set<string>([reference.fullSlug]);
+    const hrefKey = reference.href.replace(/^\//, "");
+    if (hrefKey) {
+      keys.add(hrefKey);
+    }
+
+    for (const key of keys) {
+      referencesByKey.set(key, reference);
+    }
+
+    const leafSlug = getLeafSlug(reference.fullSlug);
+    const leafMatches = referencesByLeaf.get(leafSlug) || [];
+    leafMatches.push(reference);
+    referencesByLeaf.set(leafSlug, leafMatches);
+  }
+
+  return {
+    resolve({ target }: { target: string }): NoteReference | null {
+      const normalizedTarget = normalizeNoteTarget(target);
+      const exactMatch = referencesByKey.get(normalizedTarget);
+      if (exactMatch) {
+        return exactMatch;
+      }
+
+      const leafMatches = referencesByLeaf.get(normalizedTarget) || [];
+      return leafMatches.length === 1 ? leafMatches[0] : null;
+    },
+  };
+}

--- a/src/lib/responsive-images.test.ts
+++ b/src/lib/responsive-images.test.ts
@@ -25,11 +25,41 @@ describe("createResponsiveImageHelpers", () => {
         thumbnailSizes: [320, 640],
       })
     ).toEqual({
-      src: "/attachments/%E6%88%AA%E5%9C%96%202026.png",
+      src: "/api/vault-public/_thumbnails/attachments/%E6%88%AA%E5%9C%96%202026-640.webp",
       srcSet:
-        "/_thumbnails/attachments/%E6%88%AA%E5%9C%96%202026-320.webp 320w, /_thumbnails/attachments/%E6%88%AA%E5%9C%96%202026-640.webp 640w",
+        "/api/vault-public/_thumbnails/attachments/%E6%88%AA%E5%9C%96%202026-320.webp 320w, /api/vault-public/_thumbnails/attachments/%E6%88%AA%E5%9C%96%202026-640.webp 640w",
       sizes: "100vw",
     });
+  });
+
+  it("builds absolute CDN thumbnail URLs when imageHost is configured", () => {
+    expect(
+      helpers.getResponsiveImageAttributes({
+        src: "/attachments/pic.png",
+        thumbnailSizes: [320, 640],
+        assetUrlConfig: {
+          imageHost: "https://cdn.example.com",
+          siteId: "site-a",
+          s3SubDir: "content",
+          mode: "absolute",
+        },
+      })
+    ).toEqual({
+      src: "https://cdn.example.com/site-a/content/_thumbnails/attachments/pic-640.webp",
+      srcSet:
+        "https://cdn.example.com/site-a/content/_thumbnails/attachments/pic-320.webp 320w, https://cdn.example.com/site-a/content/_thumbnails/attachments/pic-640.webp 640w",
+      sizes: "100vw",
+    });
+  });
+
+  it("does not generate absolute thumbnail URLs without imageHost", () => {
+    expect(
+      helpers.getResponsiveImageAttributes({
+        src: "/attachments/pic.png",
+        thumbnailSizes: [320],
+        assetUrlConfig: { mode: "absolute", siteId: "site-a", s3SubDir: "content" },
+      })
+    ).toBeNull();
   });
 
   it("skips remote and generated thumbnail sources", () => {
@@ -37,5 +67,4 @@ describe("createResponsiveImageHelpers", () => {
     expect(helpers.getResponsiveImageAttributes({ src: "/_thumbnails/image-320.webp", thumbnailSizes: [320] })).toBeNull();
   });
 });
-
 

--- a/src/lib/responsive-images.ts
+++ b/src/lib/responsive-images.ts
@@ -15,6 +15,21 @@ export type ResponsiveImageDeps = {
   encodeUri: (uri: string) => string;
 };
 
+export type AssetUrlMode = "app-relative" | "absolute";
+
+export type AssetUrlConfig = {
+  imageHost?: string;
+  siteId?: string;
+  s3SubDir?: 'public' | 'content';
+  mode?: AssetUrlMode;
+};
+
+export type ResponsiveImageAttributes = {
+  src: string;
+  srcSet: string;
+  sizes: string;
+};
+
 export function createResponsiveImageHelpers(deps: ResponsiveImageDeps) {
   function normalizeThumbnailSizes(sizes: readonly number[] | undefined): number[] {
     const sourceSizes = sizes && sizes.length > 0 ? sizes : deps.defaultThumbnailSizes;
@@ -38,10 +53,12 @@ export function createResponsiveImageHelpers(deps: ResponsiveImageDeps) {
   function getResponsiveImageAttributes({
     src,
     thumbnailSizes,
+    assetUrlConfig,
   }: {
     src: string;
     thumbnailSizes: readonly number[];
-  }): { src: string; srcSet: string; sizes: string } | null {
+    assetUrlConfig?: AssetUrlConfig;
+  }): ResponsiveImageAttributes | null {
     if (src.startsWith('http://') || src.startsWith('https://') || src.startsWith('data:') || src.startsWith('#')) {
       return null;
     }
@@ -56,10 +73,28 @@ export function createResponsiveImageHelpers(deps: ResponsiveImageDeps) {
       return null;
     }
 
+    const mode = assetUrlConfig?.mode || 'app-relative';
+    const largestWidth = sizes[sizes.length - 1];
+    const toUrl = (filePath: string) => getAssetUrl({
+      filePath,
+      imageHost: assetUrlConfig?.imageHost,
+      siteId: assetUrlConfig?.siteId,
+      s3SubDir: assetUrlConfig?.s3SubDir || 'content',
+      mode,
+    });
+
+    if (mode === 'absolute' && !assetUrlConfig?.imageHost) {
+      return null;
+    }
+
     const srcSet = sizes
-      .map((size) => `${deps.encodeUri(`/${getThumbnailPath({ imagePath: cleanSrc, width: size })}`)} ${size}w`)
+      .map((size) => `${deps.encodeUri(toUrl(getThumbnailPath({ imagePath: cleanSrc, width: size })))} ${size}w`)
       .join(', ');
-    return { src: deps.encodeUri(`/${cleanSrc}`), srcSet, sizes: deps.responsiveImageSizes };
+    return {
+      src: deps.encodeUri(toUrl(getThumbnailPath({ imagePath: cleanSrc, width: largestWidth }))),
+      srcSet,
+      sizes: deps.responsiveImageSizes,
+    };
   }
 
   return {
@@ -92,18 +127,23 @@ export function getAssetUrl({
   siteId,
   s3SubDir,
   filePath,
-  domain,
+  mode = 'app-relative',
 }: {
   imageHost?: string;
-  siteId: string;
-  s3SubDir: 'public' | 'content';
+  siteId?: string;
+  s3SubDir?: 'public' | 'content';
   filePath: string;
-  domain?: string;
+  mode?: AssetUrlMode;
 }): string {
   const cleanPath = filePath.replace(/^\//, '');
   if (imageHost) {
+    if (!siteId || !s3SubDir) {
+      throw new Error('siteId and s3SubDir are required when imageHost is configured.');
+    }
     return `${imageHost.replace(/\/+$/, '')}/${siteId}/${s3SubDir}/${cleanPath}`;
   }
-  return `https://${domain || 'localhost'}/api/vault-public/${cleanPath}`;
+  if (mode === 'absolute') {
+    throw new Error('imageHost is required for absolute asset URLs.');
+  }
+  return `/api/vault-public/${cleanPath}`;
 }
-

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { resolveVaultRequest, VaultConfig, clearVaultCache } from "./vault";
+import { resolveVaultRequest, fetchNoteReferencesForMarkdown, VaultConfig, VaultRootIndex, clearVaultCache } from "./vault";
 import * as s3 from "./s3";
 import { INDEX_SLUG } from "./constants";
 
@@ -21,7 +21,7 @@ describe("Vault Resolution (Unit Tests)", () => {
 
   it("should resolve a root page correctly", async () => {
     // 1. Mock root.json
-    const mockRoot = {
+    const mockRoot: VaultRootIndex = {
       version: 1,
       pages: [{ title: "Home", slug: INDEX_SLUG, date: "2024-01-01", excerpt: "Hello" }],
       directories: [],
@@ -29,6 +29,7 @@ describe("Vault Resolution (Unit Tests)", () => {
     };
 
     vi.mocked(s3.getFileFromS3).mockResolvedValueOnce(JSON.stringify(mockRoot)); // root.json
+    vi.mocked(s3.getFileFromS3).mockRejectedValueOnce(new Error("Rendered HTML not found")); // rendered page.html
     vi.mocked(s3.getFileFromS3).mockResolvedValueOnce("# Welcome Home"); // page.md
 
     const result = await resolveVaultRequest(mockConfig, []);
@@ -41,6 +42,28 @@ describe("Vault Resolution (Unit Tests)", () => {
     
     expect(s3.getFileFromS3).toHaveBeenCalledWith("test-bucket", "test-vault/root.json");
     expect(s3.getFileFromS3).toHaveBeenCalledWith("test-bucket", `test-vault/content/${INDEX_SLUG}.md`);
+  });
+
+  it("should attach cached rendered HTML when available", async () => {
+    const mockRoot = {
+      version: 1,
+      pages: [{ title: "Home", slug: INDEX_SLUG, date: "2024-01-01", excerpt: "Hello" }],
+      directories: [],
+      publicFiles: [],
+    };
+
+    vi.mocked(s3.getFileFromS3)
+      .mockResolvedValueOnce(JSON.stringify(mockRoot))
+      .mockResolvedValueOnce("<p>Cached home</p>");
+
+    const result = await resolveVaultRequest(mockConfig, []);
+
+    expect(result?.type).toBe("markdown");
+    if (result?.type === "markdown") {
+      expect(result.renderedHtml).toBe("<p>Cached home</p>");
+      expect(result.content).toBe("");
+    }
+    expect(s3.getFileFromS3).toHaveBeenCalledWith("test-bucket", "test-vault/_rendered/content/page.html");
   });
 
   it("should return null if root.json is missing", async () => {
@@ -126,6 +149,7 @@ describe("Vault Resolution (Unit Tests)", () => {
     vi.mocked(s3.getFileFromS3)
       .mockResolvedValueOnce(JSON.stringify(mockRoot))
       .mockResolvedValueOnce(JSON.stringify(mockBlogIndex))
+      .mockRejectedValueOnce(new Error("Rendered HTML not found"))
       .mockResolvedValueOnce("# Welcome to the Blog");
 
     const result = await resolveVaultRequest(mockConfig, ["blog"]);
@@ -135,5 +159,169 @@ describe("Vault Resolution (Unit Tests)", () => {
       expect(result.metadata.title).toBe("Blog Home");
       expect(result.content).toBe("# Welcome to the Blog");
     }
+  });
+
+  it("should resolve note links and embedded note content from nested directory indices", async () => {
+    const mockRoot = {
+      version: 1,
+      pages: [{ title: "Root VPN", slug: "root-vpn", date: "2024-01-01", excerpt: "" }],
+      directories: ["gaming"],
+      publicFiles: [],
+    };
+    const mockGamingIndex = {
+      version: 1,
+      pages: [{ title: "Gaming VPN Promotion", slug: "vpn-promotion-for-games", date: "2024-01-02", excerpt: "" }],
+    };
+
+    vi.mocked(s3.getFileFromS3)
+      .mockResolvedValueOnce(JSON.stringify(mockGamingIndex))
+      .mockResolvedValueOnce(
+        [
+          "---",
+          'title: "Gaming VPN Promotion"',
+          "---",
+          "# Gaming VPN Promotion",
+          "",
+          "Embedded body only.",
+        ].join("\n")
+      );
+
+    const references = await fetchNoteReferencesForMarkdown({
+      config: mockConfig,
+      markdown: "Read [[root-vpn]] and embed ![[vpn-promotion-for-games]].",
+      rootIndex: mockRoot,
+    });
+
+    expect(references).toContainEqual({
+      fullSlug: "root-vpn",
+      title: "Root VPN",
+      href: "/root-vpn",
+    });
+    expect(references).toContainEqual({
+      fullSlug: "gaming/vpn-promotion-for-games",
+      title: "Gaming VPN Promotion",
+      href: "/gaming/vpn-promotion-for-games",
+      content: "Embedded body only.",
+    });
+    expect(s3.getFileFromS3).toHaveBeenCalledWith("test-bucket", "test-vault/content/gaming/index.json");
+    expect(s3.getFileFromS3).toHaveBeenCalledWith(
+      "test-bucket",
+      "test-vault/content/gaming/vpn-promotion-for-games.md"
+    );
+  });
+
+  it("should recursively resolve note links inside embedded note content", async () => {
+    const mockRoot = {
+      version: 1,
+      pages: [
+        { title: "First Embed", slug: "first-embed", date: "2024-01-01", excerpt: "" },
+        { title: "Second Embed", slug: "second-embed", date: "2024-01-02", excerpt: "" },
+        { title: "Linked Note", slug: "linked-note", date: "2024-01-03", excerpt: "" },
+      ],
+      directories: [],
+      publicFiles: [],
+    };
+
+    vi.mocked(s3.getFileFromS3)
+      .mockResolvedValueOnce(
+        [
+          "---",
+          'title: "First Embed"',
+          "---",
+          "# First Embed",
+          "",
+          "First body.",
+          "",
+          "![[second-embed]]",
+          "",
+          "[[linked-note]]",
+        ].join("\n")
+      )
+      .mockResolvedValueOnce(
+        [
+          "---",
+          'title: "Second Embed"',
+          "---",
+          "# Second Embed",
+          "",
+          "Second body.",
+        ].join("\n")
+      );
+
+    const references = await fetchNoteReferencesForMarkdown({
+      config: mockConfig,
+      markdown: "Main ![[first-embed]].",
+      rootIndex: mockRoot,
+    });
+
+    expect(references).toContainEqual({
+      fullSlug: "first-embed",
+      title: "First Embed",
+      href: "/first-embed",
+      content: "First body.\n\n![[second-embed]]\n\n[[linked-note]]",
+    });
+    expect(references).toContainEqual({
+      fullSlug: "second-embed",
+      title: "Second Embed",
+      href: "/second-embed",
+      content: "Second body.",
+    });
+    expect(references).toContainEqual({
+      fullSlug: "linked-note",
+      title: "Linked Note",
+      href: "/linked-note",
+    });
+  });
+
+  it("should resolve private note includes for embeds without making them linkable", async () => {
+    const privateIncludes: VaultRootIndex["noteIncludes"] = [
+      {
+        fullSlug: "vpn-promotion-for-games",
+        title: "VPN Promotion",
+        filePath: "_includes/vpn-promotion-for-games.md",
+        linkable: false,
+      },
+    ];
+    const mockRoot: VaultRootIndex = {
+      version: 1,
+      pages: [{ title: "Public Note", slug: "public-note", date: "2024-01-01", excerpt: "" }],
+      directories: [],
+      publicFiles: [],
+      noteIncludes: privateIncludes,
+    };
+
+    vi.mocked(s3.getFileFromS3).mockResolvedValueOnce(
+      [
+        "---",
+        'title: "VPN Promotion"',
+        "---",
+        "# VPN Promotion",
+        "",
+        "Private promotion body with [[public-note]].",
+      ].join("\n")
+    );
+
+    const references = await fetchNoteReferencesForMarkdown({
+      config: mockConfig,
+      markdown: "Embed ![[vpn-promotion-for-games]] and link [[vpn-promotion-for-games]].",
+      rootIndex: mockRoot,
+    });
+
+    expect(references).toContainEqual(expect.objectContaining({
+      fullSlug: "vpn-promotion-for-games",
+      title: "VPN Promotion",
+      href: "/vpn-promotion-for-games",
+      linkable: false,
+      content: "Private promotion body with [[public-note]].",
+    }));
+    expect(references).toContainEqual({
+      fullSlug: "public-note",
+      title: "Public Note",
+      href: "/public-note",
+    });
+    expect(s3.getFileFromS3).toHaveBeenCalledWith(
+      "test-bucket",
+      "test-vault/_includes/vpn-promotion-for-games.md"
+    );
   });
 });

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
 import { getFileFromS3 } from "./s3";
-import { DEFAULT_THUMBNAIL_SIZES, INDEX_SLUG, INDEX_JSON, ROOT_JSON } from "./constants";
+import { DEFAULT_THUMBNAIL_SIZES, INDEX_SLUG, INDEX_JSON, ROOT_JSON, RENDERED_DIR } from "./constants";
 import { createCache } from "./cache";
+import matter from "gray-matter";
+import {
+  createNoteReferenceResolver,
+  extractWikilinkTargets,
+  type NoteReference,
+  type NoteReferenceInput,
+} from "./note-links";
 
 export const PageMetadataSchema = z.object({
   title: z.string(),
@@ -20,6 +27,12 @@ export const VaultRootIndexSchema = VaultDirectoryIndexSchema.extend({
   directories: z.array(z.string()),
   publicFiles: z.array(z.string()),
   assetFiles: z.array(z.string()).optional(),
+  noteIncludes: z.array(z.object({
+    fullSlug: z.string(),
+    title: z.string(),
+    filePath: z.string(),
+    linkable: z.literal(false).optional(),
+  })).optional(),
   thumbnailSizes: z.array(z.number().int().positive()).optional(),
 });
 
@@ -29,7 +42,14 @@ export type VaultRootIndex = z.infer<typeof VaultRootIndexSchema>;
 export type VaultIndex = VaultDirectoryIndex | VaultRootIndex;
 
 export type VaultContent =
-  | { type: "markdown"; content: string; matchedSlug: string; metadata: PageMetadata; thumbnailSizes: readonly number[] }
+  | {
+      type: "markdown";
+      content: string;
+      renderedHtml?: string;
+      matchedSlug: string;
+      metadata: PageMetadata;
+      thumbnailSizes: readonly number[];
+    }
   | { type: "collection"; pages: PageMetadata[]; requestedSlug: string }
   | { type: "asset"; filePath: string };
 
@@ -87,6 +107,137 @@ export async function fetchDirectoryIndex(config: VaultConfig, subPath: string):
   return fetchIndex(config, subPath, `content/${subPath}/${INDEX_JSON}`, VaultDirectoryIndexSchema);
 }
 
+async function fetchRenderedHtml(config: VaultConfig, fullSlug: string): Promise<string | undefined> {
+  try {
+    return await getFileFromS3(config.bucketName, `${config.vaultRoot}/${RENDERED_DIR}/content/${fullSlug}.html`);
+  } catch {
+    return undefined;
+  }
+}
+
+function stripFirstMarkdownHeading(markdown: string): string {
+  return markdown.replace(/^#\s+.+$/m, "").trim();
+}
+
+function buildNoteReferenceInputs({
+  rootIndex,
+  directoryIndices,
+}: {
+  rootIndex: VaultRootIndex;
+  directoryIndices: ReadonlyMap<string, VaultDirectoryIndex>;
+}): NoteReferenceInput[] {
+  const noteReferences: NoteReferenceInput[] = rootIndex.pages.map((page) => ({
+    fullSlug: page.slug,
+    title: page.title,
+  }));
+
+  for (const [directory, directoryIndex] of directoryIndices.entries()) {
+    for (const page of directoryIndex.pages) {
+      noteReferences.push({
+        fullSlug: `${directory}/${page.slug}`,
+        title: page.title,
+      });
+    }
+  }
+
+  return noteReferences;
+}
+
+export async function fetchNoteReferencesForMarkdown({
+  config,
+  markdown,
+  rootIndex,
+}: {
+  config: VaultConfig;
+  markdown: string;
+  rootIndex: VaultRootIndex;
+}): Promise<NoteReference[]> {
+  const wikilinkTargets = extractWikilinkTargets(markdown);
+  if (wikilinkTargets.links.length === 0 && wikilinkTargets.embeds.length === 0) {
+    return [];
+  }
+
+  const directoryEntries = await Promise.all(
+    rootIndex.directories.map(async (directory): Promise<[string, VaultDirectoryIndex] | null> => {
+      const directoryIndex = await fetchDirectoryIndex(config, directory);
+      return directoryIndex ? [directory, directoryIndex] : null;
+    })
+  );
+  const directoryIndices = new Map(directoryEntries.filter((entry): entry is [string, VaultDirectoryIndex] => entry !== null));
+  const referenceInputs = buildNoteReferenceInputs({ rootIndex, directoryIndices });
+  const publicResolver = createNoteReferenceResolver({ notes: referenceInputs });
+  const embedResolver = createNoteReferenceResolver({ notes: [...referenceInputs, ...(rootIndex.noteIncludes || [])] });
+  const privateIncludesBySlug = new Map((rootIndex.noteIncludes || []).map((include) => [include.fullSlug, include]));
+  const referencesByFullSlug = new Map<string, NoteReference>();
+  const embedTargetsToFetch = [...wikilinkTargets.embeds];
+  const fetchedEmbedSlugs = new Set<string>();
+
+  for (const target of wikilinkTargets.links) {
+    const reference = publicResolver.resolve({ target });
+    if (reference) {
+      referencesByFullSlug.set(reference.fullSlug, reference);
+    }
+  }
+
+  for (const target of wikilinkTargets.embeds) {
+    const reference = embedResolver.resolve({ target });
+    if (reference) {
+      referencesByFullSlug.set(reference.fullSlug, reference);
+    }
+  }
+
+  while (embedTargetsToFetch.length > 0) {
+    const target = embedTargetsToFetch.shift();
+    if (!target) {
+      continue;
+    }
+
+    const reference = embedResolver.resolve({ target });
+    if (!reference) {
+      continue;
+    }
+    if (fetchedEmbedSlugs.has(reference.fullSlug)) {
+      continue;
+    }
+    fetchedEmbedSlugs.add(reference.fullSlug);
+
+    try {
+      const privateInclude = privateIncludesBySlug.get(reference.fullSlug);
+      const embeddedMarkdown = await getFileFromS3(
+        config.bucketName,
+        privateInclude
+          ? `${config.vaultRoot}/${privateInclude.filePath}`
+          : `${config.vaultRoot}/content/${reference.fullSlug}.md`
+      );
+      const { content } = matter(embeddedMarkdown);
+      const bodyContent = stripFirstMarkdownHeading(content);
+      referencesByFullSlug.set(reference.fullSlug, {
+        ...reference,
+        content: bodyContent,
+      });
+
+      const nestedTargets = extractWikilinkTargets(bodyContent);
+      for (const nestedTarget of nestedTargets.links) {
+        const nestedReference = publicResolver.resolve({ target: nestedTarget });
+        if (nestedReference) {
+          referencesByFullSlug.set(nestedReference.fullSlug, nestedReference);
+        }
+      }
+      for (const nestedTarget of nestedTargets.embeds) {
+        const nestedReference = embedResolver.resolve({ target: nestedTarget });
+        if (nestedReference) {
+          referencesByFullSlug.set(nestedReference.fullSlug, nestedReference);
+        }
+      }
+      embedTargetsToFetch.push(...nestedTargets.embeds);
+    } catch (error) {
+      console.warn(`Failed to fetch embedded note "${reference.fullSlug}" for ${config.vaultRoot}:`, error);
+    }
+  }
+
+  return [...referencesByFullSlug.values()];
+}
+
 /**
  * Resolves a request by jumping directly to the correct index using the master directory map.
  */
@@ -109,8 +260,11 @@ export async function resolveVaultRequest(config: VaultConfig, slugArray?: strin
   // 3a. Is it a page at the root level?
   const rootPageMatch = rootIndex.pages.find(p => p.slug === requestedSlug);
   if (rootPageMatch) {
-    const markdown = await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${rootPageMatch.slug}.md`);
-    return { type: "markdown", content: markdown, matchedSlug: rootPageMatch.slug, metadata: rootPageMatch, thumbnailSizes };
+    const renderedHtml = await fetchRenderedHtml(config, rootPageMatch.slug);
+    const markdown = renderedHtml
+      ? ""
+      : await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${rootPageMatch.slug}.md`);
+    return { type: "markdown", content: markdown, renderedHtml, matchedSlug: rootPageMatch.slug, metadata: rootPageMatch, thumbnailSizes };
   }
 
   // 3b. Is it a page in a nested directory? (Direct Jump)
@@ -122,8 +276,11 @@ export async function resolveVaultRequest(config: VaultConfig, slugArray?: strin
     const nestedMatch = dirIndex?.pages.find(p => p.slug === lastSegment);
     if (nestedMatch) {
       // requestedSlug is the full path required for S3
-      const markdown = await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${requestedSlug}.md`);
-      return { type: "markdown", content: markdown, matchedSlug: requestedSlug, metadata: nestedMatch, thumbnailSizes };
+      const renderedHtml = await fetchRenderedHtml(config, requestedSlug);
+      const markdown = renderedHtml
+        ? ""
+        : await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${requestedSlug}.md`);
+      return { type: "markdown", content: markdown, renderedHtml, matchedSlug: requestedSlug, metadata: nestedMatch, thumbnailSizes };
     }
   }
 
@@ -138,8 +295,11 @@ export async function resolveVaultRequest(config: VaultConfig, slugArray?: strin
       const indexMatch = dirIndex.pages.find(p => p.slug === INDEX_SLUG);
       if (indexMatch) {
         const fullPath = targetDir ? `${targetDir}/${INDEX_SLUG}` : INDEX_SLUG;
-        const markdown = await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${fullPath}.md`);
-        return { type: "markdown", content: markdown, matchedSlug: fullPath, metadata: indexMatch, thumbnailSizes };
+        const renderedHtml = await fetchRenderedHtml(config, fullPath);
+        const markdown = renderedHtml
+          ? ""
+          : await getFileFromS3(config.bucketName, `${config.vaultRoot}/content/${fullPath}.md`);
+        return { type: "markdown", content: markdown, renderedHtml, matchedSlug: fullPath, metadata: indexMatch, thumbnailSizes };
       }
 
       // Priority 2: Return collection view

--- a/src/lib/wordpress-blocks.test.ts
+++ b/src/lib/wordpress-blocks.test.ts
@@ -32,7 +32,7 @@ describe("serializeHtmlToWordPressBlocks", () => {
     expect(result).toContain('<!-- wp:list {"ordered":true} -->');
     expect(result).toContain("<ol><li>One</li><li>Two</li></ol>");
     expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
-    expect(result).toContain('<figure class="size-large wp-block-image"><img src="/image.png" alt="Image"></figure>');
+    expect(result).toContain('<figure class="size-large wp-block-image"><img src="/image.png" alt="Image" /></figure>');
   });
 
   it("normalizes image blocks to Gutenberg-compatible markup", () => {
@@ -43,7 +43,7 @@ describe("serializeHtmlToWordPressBlocks", () => {
     expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"image-figure"} -->');
     expect(result).toContain('<figure class="size-large wp-block-image image-figure">');
     expect(result).toContain(
-      '<img src="/image.png" style="max-width: 100%;" srcset="/image-320.png 320w" sizes="100vw" loading="lazy" decoding="async" alt="Image">'
+      '<img src="/image.png" style="max-width: 100%;" srcset="/image-320.png 320w" sizes="100vw" loading="lazy" decoding="async" alt="Image" />'
     );
     expect(result).toContain('<figcaption class="wp-element-caption">Image caption</figcaption>');
     expect(result).not.toContain('style="height: auto !important;"');
@@ -91,6 +91,15 @@ describe("serializeHtmlToWordPressBlocks", () => {
 
     expect(result).toContain('<!-- wp:html -->\n<img src="/image.png">\n<!-- /wp:html -->');
     expect(result).toContain("<!-- wp:paragraph -->\n<p>After image</p>\n<!-- /wp:paragraph -->");
+  });
+
+  it("adds empty alt text and self-closes image tags for WordPress validation", () => {
+    const result = serializeHtmlToWordPressBlocks(
+      '<figure class="wp-block-image"><img src="/zelda-map.webp"><figcaption>Map caption</figcaption></figure>'
+    );
+
+    expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->');
+    expect(result).toContain('<figure class="size-large wp-block-image"><img src="/zelda-map.webp" alt="" /><figcaption class="wp-element-caption">Map caption</figcaption></figure>');
   });
 
   it("reads table block classes only from the top-level figure", () => {

--- a/src/lib/wordpress-blocks.test.ts
+++ b/src/lib/wordpress-blocks.test.ts
@@ -42,11 +42,14 @@ describe("serializeHtmlToWordPressBlocks", () => {
 
     expect(result).toContain('<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"image-figure"} -->');
     expect(result).toContain('<figure class="size-large wp-block-image image-figure">');
-    expect(result).toContain(
-      '<img src="/image.png" style="max-width: 100%;" srcset="/image-320.png 320w" sizes="100vw" loading="lazy" decoding="async" alt="Image" />'
-    );
+    expect(result).toContain('<img src="/image.png" alt="Image" />');
     expect(result).toContain('<figcaption class="wp-element-caption">Image caption</figcaption>');
     expect(result).not.toContain('style="height: auto !important;"');
+    expect(result).not.toContain('style="max-width: 100%;"');
+    expect(result).not.toContain('srcset=');
+    expect(result).not.toContain('sizes=');
+    expect(result).not.toContain('loading=');
+    expect(result).not.toContain('decoding=');
   });
 
   it("normalizes quote blocks to Gutenberg-compatible markup", () => {

--- a/src/lib/wordpress-blocks.test.ts
+++ b/src/lib/wordpress-blocks.test.ts
@@ -105,6 +105,15 @@ describe("serializeHtmlToWordPressBlocks", () => {
     expect(result).toContain('<figure class="size-large wp-block-image"><img src="/zelda-map.webp" alt="" /><figcaption class="wp-element-caption">Map caption</figcaption></figure>');
   });
 
+  it("normalizes existing self-closed image tags to WordPress spacing", () => {
+    const result = serializeHtmlToWordPressBlocks(
+      '<figure class="wp-block-image"><img src="/image.png" alt="Image"/></figure>'
+    );
+
+    expect(result).toContain('<figure class="size-large wp-block-image"><img src="/image.png" alt="Image" /></figure>');
+    expect(result).not.toContain('alt="Image"/>');
+  });
+
   it("reads table block classes only from the top-level figure", () => {
     const result = serializeHtmlToWordPressBlocks(
       '<figure><table><tbody><tr><td><span class="is-style-stripes">Nested</span></td></tr></tbody></table></figure>'

--- a/src/lib/wordpress-blocks.ts
+++ b/src/lib/wordpress-blocks.ts
@@ -182,11 +182,7 @@ function ensureImageAltAttribute(html: string): string {
 
 function selfCloseImageTags(html: string): string {
   return html.replace(/<img\b[^>]*>/gi, (openingTag: string) => {
-    if (/\/\s*>$/.test(openingTag)) {
-      return openingTag;
-    }
-
-    return openingTag.replace(/\s*>$/, " />");
+    return openingTag.replace(/\s*\/?>$/, " />");
   });
 }
 

--- a/src/lib/wordpress-blocks.ts
+++ b/src/lib/wordpress-blocks.ts
@@ -155,6 +155,26 @@ function stripAttributeFromElements({
   });
 }
 
+function ensureImageAltAttribute(html: string): string {
+  return html.replace(/<img\b[^>]*>/gi, (openingTag: string) => {
+    if (/\salt\s*=/i.test(openingTag)) {
+      return openingTag;
+    }
+
+    return openingTag.replace(/\s*\/?>$/, ' alt="">');
+  });
+}
+
+function selfCloseImageTags(html: string): string {
+  return html.replace(/<img\b[^>]*>/gi, (openingTag: string) => {
+    if (/\/\s*>$/.test(openingTag)) {
+      return openingTag;
+    }
+
+    return openingTag.replace(/\s*>$/, " />");
+  });
+}
+
 function normalizeTableHtml(html: string): string {
   return stripAttributeFromElements({
     html: addClassToElements({ html, tagName: "table", className: "has-fixed-layout" }),
@@ -293,11 +313,15 @@ function serializeTableBlock(html: string): string {
 }
 
 function serializeImageBlock(html: string): string {
-  const normalizedHtml = addClassToElements({
+  const withCaptionClass = addClassToElements({
     html: normalizeImageHtml(html),
     tagName: "figcaption",
     className: WORDPRESS_CAPTION_CLASS,
   });
+
+  // Keep the existing class order and responsive img attributes; WordPress block
+  // validation only requires the missing empty alt plus self-closed img structure.
+  const normalizedHtml = selfCloseImageTags(ensureImageAltAttribute(withCaptionClass));
 
   return wrapWordPressBlock({
     blockName: "image",

--- a/src/lib/wordpress-blocks.ts
+++ b/src/lib/wordpress-blocks.ts
@@ -155,6 +155,21 @@ function stripAttributeFromElements({
   });
 }
 
+function stripAttributesFromElements({
+  html,
+  tagNames,
+  attributeNames,
+}: {
+  html: string;
+  tagNames: readonly string[];
+  attributeNames: readonly string[];
+}): string {
+  return attributeNames.reduce(
+    (currentHtml, attributeName) => stripAttributeFromElements({ html: currentHtml, tagNames, attributeName }),
+    html
+  );
+}
+
 function ensureImageAltAttribute(html: string): string {
   return html.replace(/<img\b[^>]*>/gi, (openingTag: string) => {
     if (/\salt\s*=/i.test(openingTag)) {
@@ -186,10 +201,18 @@ function normalizeTableHtml(html: string): string {
 function normalizeImageHtml(html: string): string {
   const imageBlockHtml = addClassToOpeningTag({ html, tagName: "figure", className: WORDPRESS_IMAGE_CLASS });
   const largeImageHtml = addClassToOpeningTag({ html: imageBlockHtml, tagName: "figure", className: "size-large" });
-  return stripAttributeFromElements({
+  const withoutFigureStyle = stripAttributeFromElements({
     html: largeImageHtml,
     tagNames: ["figure"],
     attributeName: "style",
+  });
+  // The markdown/cache renderer may add runtime responsive attributes. Core
+  // image block validation compares against saved block markup, so do not carry
+  // those runtime-only img attributes into the WordPress post body.
+  return stripAttributesFromElements({
+    html: withoutFigureStyle,
+    tagNames: ["img"],
+    attributeNames: ["style", "srcset", "sizes", "loading", "decoding"],
   });
 }
 
@@ -319,8 +342,9 @@ function serializeImageBlock(html: string): string {
     className: WORDPRESS_CAPTION_CLASS,
   });
 
-  // Keep the existing class order and responsive img attributes; WordPress block
-  // validation only requires the missing empty alt plus self-closed img structure.
+  // After runtime attrs are removed, keep WordPress's expected img structure:
+  // explicit empty alt for decorative/caption-only images and XHTML-style
+  // self-closing syntax. Source markdown image syntax must not affect this shape.
   const normalizedHtml = selfCloseImageTags(ensureImageAltAttribute(withCaptionClass));
 
   return wrapWordPressBlock({


### PR DESCRIPTION
## Summary
- Add note wikilink and recursive transclusion support, including private include paths outside public content.
- Generate and serve cached rendered HTML while keeping Markdown as the source of truth.
- Unify responsive thumbnail URL generation across regular rendering and WordPress publishing.
- Normalize WordPress image block output to saved block markup and document wikilink behavior with generic examples.

## Verification
- npm run type-check
- npm run test