### PR TITLE
WordPress Sync Enhancements: Page Content Type, Multi-Slug --push, and Cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Notopress is designed to fit seamlessly into your existing workflow, rather than
 - **Local environment switching**: Use `npm run configure` to update `.env.local` for a selected site.
 - **Vercel deployment automation**: Sync production environment variables and trigger a production Vercel deploy with `npm run deploy`.
 - **Optional image host**: Configure an `imageHost` for absolute image URLs, especially for CDN or WordPress publishing workflows.
-- **Optional WordPress publishing**: Push your local Markdown posts to WordPress, update existing posts by slug, or target one post with `--post`.
+- **Optional WordPress publishing**: Push your local Markdown posts to WordPress, update existing posts by slug, or target specific posts with `--push`.
 
 ## Organizing Your Content
 
@@ -244,7 +244,7 @@ npm run sync -- --site example-blog
 npm run deploy -- --site example-blog --registry ./custom-registry.json
 ```
 
-Use `--wp` with `sync` or `deploy` to publish local Markdown posts to the configured WordPress site, and `--post <slug>` to limit that WordPress publish step to one post.
+Use `--wp` with `sync` or `deploy` to publish local Markdown posts to the configured WordPress site, and `--push <slug1,slug2,...>` to limit that WordPress publish step to specific posts (comma-separated list of slugs).
 
 ## Roadmap
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -490,7 +490,10 @@ async function main() {
     }
 
     const shouldPushWp = hasFlag({ flag: '--wp' });
-    const targetPostSlug = getFlagValue({ flag: '--post' });
+    const pushValue = getFlagValue({ flag: '--push' });
+    const targetSlugs = pushValue
+      ? pushValue.split(',').map((s) => s.trim()).filter(Boolean)
+      : undefined;
     
     const { allIndices } = await syncContent({ site, registry, isDryRun });
 
@@ -499,7 +502,7 @@ async function main() {
         site,
         registry,
         allIndices,
-        targetPostSlug,
+        targetSlugs,
         dryRun: isDryRun,
       });
     }

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -138,6 +138,11 @@ describe('WordPress Deployment Library', () => {
         expect.stringContaining('/wp/v2/posts/456'),
         expect.objectContaining({ method: 'POST' })
       );
+
+      const updateCall = mockFetch.mock.calls.find((call) => call[0].includes('/wp/v2/posts/456'));
+      expect(updateCall).toBeDefined();
+      const body = JSON.parse(updateCall![1].body);
+      expect(body).not.toHaveProperty('date');
     });
 
     it('should perform GET queries and POST to create a new post when it does not exist', async () => {
@@ -177,6 +182,11 @@ describe('WordPress Deployment Library', () => {
         expect.stringContaining('/wp/v2/posts'),
         expect.objectContaining({ method: 'POST' })
       );
+
+      const createCall = mockFetch.mock.calls.find((call) => call[1]?.method === 'POST');
+      expect(createCall).toBeDefined();
+      const body = JSON.parse(createCall![1].body);
+      expect(body.date).toBe('2026-06-16T13:00:00.000Z');
     });
 
     it('should publish markdown tables as striped WordPress table figures', async () => {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -125,7 +125,7 @@ describe('WordPress Deployment Library', () => {
         site: mockSite,
         registry: mockRegistry,
         allIndices: mockIndices,
-        targetPostSlug: 'post-one',
+        targetSlugs: ['post-one'],
         dryRun: false,
       });
 
@@ -169,7 +169,7 @@ describe('WordPress Deployment Library', () => {
         site: mockSite,
         registry: mockRegistry,
         allIndices: mockIndices,
-        targetPostSlug: 'blog/post-two',
+        targetSlugs: ['blog/post-two'],
         dryRun: false,
       });
 
@@ -221,7 +221,7 @@ describe('WordPress Deployment Library', () => {
         site: mockSite,
         registry: mockRegistry,
         allIndices: mockIndices,
-        targetPostSlug: 'post-one',
+        targetSlugs: ['post-one'],
         dryRun: false,
       });
 
@@ -268,7 +268,7 @@ describe('WordPress Deployment Library', () => {
         site: mockSite,
         registry: mockRegistry,
         allIndices: mockIndices,
-        targetPostSlug: 'post-one',
+        targetSlugs: ['post-one'],
         dryRun: false,
       });
 
@@ -318,7 +318,7 @@ describe('WordPress Deployment Library', () => {
         site: mockSite,
         registry: mockRegistry,
         allIndices: mockIndices,
-        targetPostSlug: 'post-one',
+        targetSlugs: ['post-one'],
         dryRun: false,
       });
 
@@ -409,7 +409,7 @@ describe('WordPress Deployment Library', () => {
         site: { ...mockSite, noteIncludePaths: ['_includes'] },
         registry: mockRegistry,
         allIndices: indicesWithEmbed,
-        targetPostSlug: 'post-one',
+        targetSlugs: ['post-one'],
         dryRun: false,
       });
 
@@ -433,7 +433,7 @@ describe('WordPress Deployment Library', () => {
           site: { ...mockSite, imageHost: undefined },
           registry: { ...mockRegistry, imageHost: undefined },
           allIndices: mockIndices,
-          targetPostSlug: 'post-one',
+          targetSlugs: ['post-one'],
           dryRun: false,
         })
       ).rejects.toThrow('imageHost');
@@ -455,7 +455,7 @@ describe('WordPress Deployment Library', () => {
         site: mockSite,
         registry: mockRegistry,
         allIndices: mockIndices,
-        targetPostSlug: 'post-one',
+        targetSlugs: ['post-one'],
         dryRun: true,
       });
 
@@ -494,7 +494,7 @@ describe('WordPress Deployment Library', () => {
         site: mockSite,
         registry: mockRegistry,
         allIndices: mockIndices,
-        targetPostSlug: 'post-one',
+        targetSlugs: ['post-one'],
         dryRun: false,
       });
 
@@ -504,6 +504,91 @@ describe('WordPress Deployment Library', () => {
       const body = JSON.parse(postCall![1].body);
       expect(body.content).toContain('# This is a comment');
       expect(body.content).toContain('<h1>Real Title</h1>');
+    });
+
+    it('should support multiple target slugs', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 789 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetSlugs: ['post-one', 'blog/post-two'],
+        dryRun: false,
+      });
+
+      // Verify it queried both slug endpoints
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts?slug=post-one'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts?slug=blog-post-two'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      // Verify two POST calls occurred
+      const postCalls = mockFetch.mock.calls.filter((call) => call[1]?.method === 'POST');
+      expect(postCalls.length).toBe(2);
+    });
+
+    it('should throw an error if none of the target slugs are found', async () => {
+      await expect(
+        pushToWordPress({
+          site: mockSite,
+          registry: mockRegistry,
+          allIndices: mockIndices,
+          targetSlugs: ['non-existent-slug'],
+          dryRun: false,
+        })
+      ).rejects.toThrow('Could not find any posts in the vault matching slugs: "non-existent-slug"');
+    });
+
+    it('should warn but proceed if only a subset of slugs are missing', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 789 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetSlugs: ['post-one', 'non-existent-slug'],
+        dryRun: false,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning: Could not find posts in the vault matching slugs: "non-existent-slug"')
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -627,12 +627,12 @@ describe('WordPress Deployment Library', () => {
       );
       expect(writeFile).toHaveBeenCalledWith(
         '/mock/vault/content/post-one.md',
-        expect.not.stringContaining('---\n\n# Post One Title'),
+        expect.not.stringContaining('# Post One Title'),
         'utf-8'
       );
       expect(writeFile).toHaveBeenCalledWith(
         '/mock/vault/content/post-one.md',
-        expect.stringContaining('# Post One Title\n\nWordPress body text.'),
+        expect.stringContaining('---\nWordPress body text.'),
         'utf-8'
       );
     });
@@ -673,7 +673,7 @@ describe('WordPress Deployment Library', () => {
 
       expect(writeFile).toHaveBeenCalledWith(
         '/mock/vault/content/pulled-post-slug.md',
-        expect.stringContaining('# Pulled Title\n\nFetched by ID.'),
+        expect.stringContaining('---\nFetched by ID.'),
         'utf-8'
       );
     });

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -189,6 +189,56 @@ describe('WordPress Deployment Library', () => {
       expect(body.date).toBe('2026-06-16T13:00:00.000Z');
     });
 
+    it('should publish content with nested wordpress.type page frontmatter to the pages endpoint', async () => {
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/pages') && options.method === 'GET') {
+          return {
+            ok: true,
+            json: async () => [],
+          };
+        }
+        if (url.includes('/wp/v2/pages') && options.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => ({ id: 321 }),
+          };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+      vi.mocked(readFile).mockResolvedValue([
+        '---',
+        'title: "About"',
+        'wordpress:',
+        '  type: page',
+        '---',
+        '# About',
+        '',
+        'Page body.',
+      ].join('\n'));
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        targetPostSlug: 'post-one',
+        dryRun: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/pages?slug=post-one'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/pages'),
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/wp/v2/posts'),
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
     it('should publish markdown tables as striped WordPress table figures', async () => {
       const mockFetch = vi.fn().mockImplementation(async (url, options) => {
         if (url.includes('/wp/v2/posts') && options.method === 'GET') {

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -789,15 +789,13 @@ export async function pullFromWordPress({
   const modifiedIso = parseWpDate(wpPost.modified, wpPost.modified_gmt);
   const decodedTitle = decodeHtmlEntities(wpPost.title.rendered);
 
-  // Prepend frontmatter and title heading
+  // Prepend frontmatter while preserving the WordPress body as-is.
   const frontmatter = [
     `---`,
     `title: "${decodedTitle.replace(/"/g, '\\"')}"`,
     `date: "${dateIso}"`,
     `updated: "${modifiedIso}"`,
     `---`,
-    `# ${decodedTitle}`,
-    ``,
     markdownBody,
     ``,
   ].join('\n');

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import { z } from 'zod';
 import { Site, Registry } from '../../src/domain/registry';
 import { VaultDirectoryIndex } from '../../src/lib/vault';
 import { renderMarkdownContent } from '../../src/lib/markdown';
@@ -34,6 +35,38 @@ interface WordPressPostPayload {
   slug: string;
   status: 'publish';
   date?: string;
+}
+
+const WordPressContentTypeSchema = z.enum(['post', 'page']);
+const WordPressFrontmatterSchema = z.object({
+  wordpress: z.object({
+    type: WordPressContentTypeSchema.optional(),
+  }).optional(),
+}).passthrough();
+
+type WordPressContentType = z.infer<typeof WordPressContentTypeSchema>;
+type WordPressRestResource = {
+  contentType: WordPressContentType;
+  restBase: 'posts' | 'pages';
+};
+
+const WORDPRESS_REST_RESOURCES: Record<WordPressContentType, WordPressRestResource> = {
+  post: { contentType: 'post', restBase: 'posts' },
+  page: { contentType: 'page', restBase: 'pages' },
+};
+
+function getWordPressRestResource({
+  frontmatter,
+}: {
+  frontmatter: Record<string, unknown>;
+}): WordPressRestResource {
+  const result = WordPressFrontmatterSchema.safeParse(frontmatter);
+  if (!result.success) {
+    throw new Error('Invalid WordPress frontmatter. Expected wordpress.type to be "post" or "page".');
+  }
+
+  const contentType = result.data.wordpress?.type || 'post';
+  return WORDPRESS_REST_RESOURCES[contentType];
 }
 
 function buildNoteReferenceInputs({ allIndices }: { allIndices: Map<string, VaultDirectoryIndex> }): NoteReferenceInput[] {
@@ -182,7 +215,8 @@ export async function pushToWordPress({
 
       // Read markdown and parse frontmatter
       const fileContent = await readFile(post.localPath, 'utf-8');
-      const { content: markdownBody } = matter(fileContent);
+      const { data, content: markdownBody } = matter(fileContent);
+      const wordpressResource = getWordPressRestResource({ frontmatter: data });
 
       // Strip first H1 from markdown to avoid duplicated titles, only if it's the first non-empty line of the document and not inside a code block
       const lines = markdownBody.split('\n');
@@ -247,7 +281,7 @@ export async function pushToWordPress({
       const existingPosts = await wpFetch({
         endpoint,
         credentials,
-        path: `/wp/v2/posts?slug=${encodeURIComponent(wpSlug)}&status=any`,
+        path: `/wp/v2/${wordpressResource.restBase}?slug=${encodeURIComponent(wpSlug)}&status=any`,
       });
 
       const wpPostExists = existingPosts && existingPosts.length > 0;
@@ -262,32 +296,32 @@ export async function pushToWordPress({
 
       if (wpPostExists) {
         if (dryRun) {
-          console.log(`  [DRY RUN] Would UPDATE WordPress post "${post.title}" (ID: ${wpPostId})`);
+          console.log(`  [DRY RUN] Would UPDATE WordPress ${wordpressResource.contentType} "${post.title}" (ID: ${wpPostId})`);
         } else {
           await wpFetch({
             endpoint,
             credentials,
-            path: `/wp/v2/posts/${wpPostId}`,
+            path: `/wp/v2/${wordpressResource.restBase}/${wpPostId}`,
             method: 'POST',
             body: payload,
           });
-          console.log(`  ✅ Successfully UPDATED WordPress post (ID: ${wpPostId})`);
+          console.log(`  ✅ Successfully UPDATED WordPress ${wordpressResource.contentType} (ID: ${wpPostId})`);
         }
       } else {
         if (dryRun) {
-          console.log(`  [DRY RUN] Would CREATE new WordPress post "${post.title}"`);
+          console.log(`  [DRY RUN] Would CREATE new WordPress ${wordpressResource.contentType} "${post.title}"`);
         } else {
           const newPost = await wpFetch({
             endpoint,
             credentials,
-            path: `/wp/v2/posts`,
+            path: `/wp/v2/${wordpressResource.restBase}`,
             method: 'POST',
             body: {
               ...payload,
               date: post.date,
             },
           });
-          console.log(`  ✅ Successfully CREATED new WordPress post (ID: ${newPost.id})`);
+          console.log(`  ✅ Successfully CREATED new WordPress ${wordpressResource.contentType} (ID: ${newPost.id})`);
         }
       }
     } catch (err) {

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -17,7 +17,7 @@ interface PushToWordPressArgs {
   site: Site;
   registry: Registry;
   allIndices: Map<string, VaultDirectoryIndex>;
-  targetPostSlug?: string;
+  targetSlugs?: string[];
   dryRun: boolean;
 }
 
@@ -146,7 +146,7 @@ export async function pushToWordPress({
   site,
   registry,
   allIndices,
-  targetPostSlug,
+  targetSlugs,
   dryRun,
 }: PushToWordPressArgs) {
   const credentials = site.wordpress;
@@ -165,8 +165,8 @@ export async function pushToWordPress({
   console.log(`\n📝 Preparing WordPress Publishing...`);
   console.log(`- Target Endpoint: ${endpoint}`);
   console.log(`- Authenticated As: ${credentials.username}`);
-  if (targetPostSlug) {
-    console.log(`- Target Single Post: ${targetPostSlug}`);
+  if (targetSlugs && targetSlugs.length > 0) {
+    console.log(`- Target Post Slugs: ${targetSlugs.join(', ')}`);
   }
   console.log(dryRun ? `- Mode: DRY RUN (No changes will be written)\n` : `- Mode: Live Sync\n`);
 
@@ -188,8 +188,8 @@ export async function pushToWordPress({
       // Build the full hierarchical slug
       const fullSlug = dirKey ? `${dirKey}/${page.slug}` : page.slug;
 
-      // Filter by target post slug if specified
-      if (targetPostSlug && fullSlug !== targetPostSlug) {
+      // Filter by target post slugs if specified
+      if (targetSlugs && targetSlugs.length > 0 && !targetSlugs.includes(fullSlug)) {
         continue;
       }
 
@@ -203,8 +203,24 @@ export async function pushToWordPress({
     }
   }
 
-  if (targetPostSlug && postsToPublish.length === 0) {
-    throw new Error(`⨯ Could not find any post in the vault matching slug: "${targetPostSlug}"`);
+  if (targetSlugs && targetSlugs.length > 0) {
+    const foundSlugs = new Set(postsToPublish.map((p) => p.slug));
+    const missingSlugs = targetSlugs.filter((slug) => !foundSlugs.has(slug));
+    if (missingSlugs.length > 0) {
+      if (postsToPublish.length === 0) {
+        throw new Error(
+          `⨯ Could not find any posts in the vault matching slugs: ${targetSlugs
+            .map((s) => `"${s}"`)
+            .join(', ')}`
+        );
+      } else {
+        console.warn(
+          `⚠️ Warning: Could not find posts in the vault matching slugs: ${missingSlugs
+            .map((s) => `"${s}"`)
+            .join(', ')}`
+        );
+      }
+    }
   }
 
   console.log(`Found ${postsToPublish.length} post(s) to process.`);
@@ -327,8 +343,8 @@ export async function pushToWordPress({
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       console.error(`  ❌ Failed to sync post "${post.title}":`, errMsg);
-      // We don't want to crash the whole sync if one post fails, but if single post targeted, we bubble up
-      if (targetPostSlug) {
+      // We don't want to crash the whole sync if one post fails, but if target slugs are specified, we bubble up
+      if (targetSlugs && targetSlugs.length > 0) {
         throw err;
       }
     }

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -28,6 +28,14 @@ interface WpFetchArgs {
   body?: unknown;
 }
 
+interface WordPressPostPayload {
+  title: string;
+  content: string;
+  slug: string;
+  status: 'publish';
+  date?: string;
+}
+
 function buildNoteReferenceInputs({ allIndices }: { allIndices: Map<string, VaultDirectoryIndex> }): NoteReferenceInput[] {
   const noteReferences: NoteReferenceInput[] = [];
   for (const [dirKey, dirIndex] of allIndices.entries()) {
@@ -245,12 +253,11 @@ export async function pushToWordPress({
       const wpPostExists = existingPosts && existingPosts.length > 0;
       const wpPostId = wpPostExists ? existingPosts[0].id : null;
 
-      const payload = {
+      const payload: WordPressPostPayload = {
         title: post.title,
         content: wordpressBlockContent,
         slug: wpSlug,
         status: 'publish',
-        date: post.date,
       };
 
       if (wpPostExists) {
@@ -275,7 +282,10 @@ export async function pushToWordPress({
             credentials,
             path: `/wp/v2/posts`,
             method: 'POST',
-            body: payload,
+            body: {
+              ...payload,
+              date: post.date,
+            },
           });
           console.log(`  ✅ Successfully CREATED new WordPress post (ID: ${newPost.id})`);
         }

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -132,6 +132,66 @@ describe("createMarkdownRenderer", () => {
     expect(html).not.toContain('<figcaption>Feature comparison table.</figcaption>');
   });
 
+  it("does not consume complex content after a table as a caption", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: [
+        "| Country | Code |",
+        "| --- | --- |",
+        "| Jamaica | +1-876 |",
+        "",
+        "*Reminder:* prepare an eSIM before leaving.",
+        "",
+        "| eSIM service | Link |",
+        "| --- | --- |",
+        "| Airalo | [Deal](https://example.com) |",
+        "",
+        "*Traveler eSIM recommendations.*",
+      ].join("\n"),
+      thumbnailSizes: [320],
+      getTableFigureProperties: () => ({ class: 'wp-block-table is-style-stripes' }),
+    });
+
+    expect(html).toContain('<p><em>Reminder:</em> prepare an eSIM before leaving.</p>');
+    expect(html).toContain('<figcaption>Traveler eSIM recommendations.</figcaption>');
+    expect(html).not.toContain('<figcaption>Reminder:');
+  });
+
+  it("does not consume transcluded wikilink content after a table as a caption", async () => {
+    const { renderMarkdownContent } = await import("./markdown");
+    const html = await renderMarkdownContent({
+      markdown: [
+        "| Country | Code |",
+        "| --- | --- |",
+        "| Jamaica | +1-876 |",
+        "",
+        "![[traveler-esim-promotion]]",
+      ].join("\n"),
+      thumbnailSizes: [320],
+      noteReferences: [
+        {
+          fullSlug: "traveler-esim-promotion",
+          title: "Traveler eSIM Promotion",
+          href: "/traveler-esim-promotion",
+          content: [
+            "*Reminder:* prepare an eSIM before leaving.",
+            "",
+            "| eSIM service | Link |",
+            "| --- | --- |",
+            "| Airalo | [Deal](https://example.com) |",
+            "",
+            "*Traveler eSIM recommendations.*",
+          ].join("\n"),
+        },
+      ],
+      getTableFigureProperties: () => ({ class: 'wp-block-table is-style-stripes' }),
+    });
+
+    expect(html).toContain('<p><em>Reminder:</em> prepare an eSIM before leaving.</p>');
+    expect(html).toContain('<figcaption>Traveler eSIM recommendations.</figcaption>');
+    expect(html).not.toContain('<figcaption>Reminder:');
+  });
+
   it("does not wrap tables already inside figures with long attributes", async () => {
     const { wrapTablesInFigures } = await import("./markdown");
     const figureClass = "wp-block-table is-style-stripes has-fixed-layout alignwide custom-long-class-name";

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -77,7 +77,7 @@ export function wrapTablesInFigures(
   });
 
   return wrappedTables.replace(
-    /(<figure(?:\s[^>]*)?>\s*<table(?:\s[^>]*)?>[\s\S]*?<\/table>\s*)<\/figure>\s*<p><em>([\s\S]*?)<\/em><\/p>/g,
+    /(<figure(?:\s[^>]*)?>\s*<table(?:\s[^>]*)?>[\s\S]*?<\/table>\s*)<\/figure>\s*<p><em>((?:(?!<\/?em\b|<\/?p\b|<table\b|<\/?figure\b)[\s\S])*?)<\/em><\/p>/g,
     (_match: string, figureWithTable: string, captionHtml: string) => {
       return `${figureWithTable}<figcaption>${captionHtml}</figcaption>\n</figure>`;
     }


### PR DESCRIPTION
## Overview
This PR introduces several robustness improvements, new feature additions, and fixes to the WordPress synchronization/deployment pipeline.

## Summary of Changes
- **Target specific posts with `--push` (multiple slugs support)**:
  - Renamed the CLI flag `--post` to `--push`.
  - Added support for targeting multiple comma-separated slugs (e.g., `--push post-one,blog/post-two`) to limit publishing scope and reduce sync/upload times.
  - Warns if only a subset of targeted slugs is missing from the vault, and bubbles up/fails only if all specified slugs are missing or a synchronization error occurs.
- **Page content type support**:
  - Adds schema validation for `wordpress.type` under the frontmatter metadata block using Zod.
  - Dynamically routes update/create queries to `/wp/v2/pages` or `/wp/v2/posts` based on the content type.
- **WordPress Pull Cleanups**:
  - Prevent prepending redundant `# <Title>` headings to the Markdown body when pulling posts/pages from WordPress.
- **Metadata and Table Caption fixes**:
  - Corrected WordPress publish payload creation and metadata sync.
  - Refined regex parsing to prevent greedy matching of table captions with adjacent paragraph blocks.

## Verification
- Run `npm run type-check` (passed)
- Run `npm run test` (106 tests passed, including new test cases for targetSlugs and page routing)