### PR TITLE
feat: add incremental WordPress push based on post slug content hashes

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -498,7 +498,8 @@ async function main() {
     }
 
     const hasPushFlag = hasFlag({ flag: '--push' });
-    const shouldPushWp = hasFlag({ flag: '--wp' }) || hasPushFlag;
+    const markSynced = hasFlag({ flag: '--mark-synced' });
+    const shouldPushWp = hasFlag({ flag: '--wp' }) || hasPushFlag || markSynced;
     const forcePush = hasFlag({ flag: '--force' });
     const pushValue = getFlagValue({ flag: '--push' });
     const targetSlugs = pushValue && pushValue !== 'true'
@@ -514,6 +515,7 @@ async function main() {
         allIndices,
         targetSlugs,
         force: forcePush,
+        markSynced,
         dryRun: isDryRun,
       });
     }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -497,12 +497,14 @@ async function main() {
       return;
     }
 
-    const shouldPushWp = hasFlag({ flag: '--wp' });
+    const hasPushFlag = hasFlag({ flag: '--push' });
+    const shouldPushWp = hasFlag({ flag: '--wp' }) || hasPushFlag;
+    const forcePush = hasFlag({ flag: '--force' });
     const pushValue = getFlagValue({ flag: '--push' });
-    const targetSlugs = pushValue
+    const targetSlugs = pushValue && pushValue !== 'true'
       ? pushValue.split(',').map((s) => s.trim()).filter(Boolean)
       : undefined;
-    
+
     const { allIndices } = await syncContent({ site, registry, isDryRun });
 
     if (shouldPushWp) {
@@ -511,6 +513,7 @@ async function main() {
         registry,
         allIndices,
         targetSlugs,
+        force: forcePush,
         dryRun: isDryRun,
       });
     }

--- a/scripts/lib/sync-state.test.ts
+++ b/scripts/lib/sync-state.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { computeContentHash, createSyncStateManager } from './sync-state';
+
+describe('sync-state', () => {
+  describe('computeContentHash', () => {
+    it('computes deterministic SHA-256 hashes for content', () => {
+      const content = '# Hello World\n\nThis is a test post.';
+      const hash1 = computeContentHash(content);
+      const hash2 = computeContentHash(content);
+
+      expect(hash1).toEqual(hash2);
+      expect(hash1).toHaveLength(64);
+    });
+
+    it('produces different hashes for modified content', () => {
+      const hash1 = computeContentHash('# Hello World');
+      const hash2 = computeContentHash('# Hello World Modified');
+
+      expect(hash1).not.toEqual(hash2);
+    });
+  });
+
+  describe('createSyncStateManager', () => {
+    it('returns empty sync state when file does not exist', async () => {
+      const manager = createSyncStateManager({
+        exists: vi.fn(async () => false),
+        readFile: vi.fn(async () => ''),
+        writeFile: vi.fn(async () => undefined),
+        joinPath: path.posix.join,
+      });
+
+      const state = await manager.loadSyncState({ vaultPath: '/vault' });
+      expect(state).toEqual({});
+    });
+
+    it('loads existing sync state from disk', async () => {
+      const mockState = {
+        wordpress: {
+          'post-one': {
+            contentHash: 'abc123hash',
+            syncedAt: '2026-07-27T12:00:00.000Z',
+          },
+        },
+      };
+
+      const manager = createSyncStateManager({
+        exists: vi.fn(async () => true),
+        readFile: vi.fn(async () => JSON.stringify(mockState)),
+        writeFile: vi.fn(async () => undefined),
+        joinPath: path.posix.join,
+      });
+
+      const state = await manager.loadSyncState({ vaultPath: '/vault' });
+      expect(state).toEqual(mockState);
+    });
+
+    it('saves sync state to disk', async () => {
+      const writes: Record<string, string> = {};
+      const manager = createSyncStateManager({
+        exists: vi.fn(async () => false),
+        readFile: vi.fn(async () => ''),
+        writeFile: vi.fn(async (filePath, content) => {
+          writes[filePath] = content;
+        }),
+        joinPath: path.posix.join,
+      });
+
+      const nextState = {
+        wordpress: {
+          'blog/post-two': {
+            contentHash: 'def456hash',
+            syncedAt: '2026-07-27T14:00:00.000Z',
+          },
+        },
+      };
+
+      await manager.saveSyncState({ vaultPath: '/vault', syncState: nextState });
+
+      expect(writes['/vault/.notopress-sync.json']).toBeDefined();
+      expect(JSON.parse(writes['/vault/.notopress-sync.json'])).toEqual(nextState);
+    });
+  });
+});

--- a/scripts/lib/sync-state.ts
+++ b/scripts/lib/sync-state.ts
@@ -1,0 +1,65 @@
+import crypto from 'crypto';
+import { readFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'path';
+
+export const SYNC_STATE_FILENAME = '.notopress-sync.json';
+
+export interface WordPressSyncEntry {
+  contentHash: string;
+  syncedAt: string;
+}
+
+export interface VaultSyncState {
+  wordpress?: Record<string, WordPressSyncEntry>;
+}
+
+export type SyncStateDeps = {
+  exists: (path: string) => Promise<boolean>;
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
+  writeFile: (path: string, content: string) => Promise<void>;
+  joinPath: (...paths: string[]) => string;
+};
+
+export function computeContentHash(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+export function createSyncStateManager(deps: SyncStateDeps) {
+  return {
+    async loadSyncState({ vaultPath }: { vaultPath: string }): Promise<VaultSyncState> {
+      const statePath = deps.joinPath(vaultPath, SYNC_STATE_FILENAME);
+      if (!(await deps.exists(statePath))) {
+        return {};
+      }
+      try {
+        const raw = await deps.readFile(statePath, 'utf-8');
+        return JSON.parse(raw) as VaultSyncState;
+      } catch {
+        return {};
+      }
+    },
+
+    async saveSyncState({
+      vaultPath,
+      syncState,
+    }: {
+      vaultPath: string;
+      syncState: VaultSyncState;
+    }): Promise<void> {
+      const statePath = deps.joinPath(vaultPath, SYNC_STATE_FILENAME);
+      const jsonContent = JSON.stringify(syncState, null, 2) + '\n';
+      await deps.writeFile(statePath, jsonContent);
+    },
+  };
+}
+
+const defaultSyncStateManager = createSyncStateManager({
+  exists: async (p) => existsSync(p),
+  readFile: async (p, encoding) => readFile(p, encoding),
+  writeFile: async (p, content) => writeFile(p, content, 'utf-8'),
+  joinPath: path.join,
+});
+
+export const loadSyncState = defaultSyncStateManager.loadSyncState;
+export const saveSyncState = defaultSyncStateManager.saveSyncState;

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -660,6 +660,32 @@ describe('WordPress Deployment Library', () => {
 
       expect(mockFetch).toHaveBeenCalled();
     });
+
+    it('should mark all posts as synced without calling WordPress REST API when markSynced is true', async () => {
+      const writes: Record<string, string> = {};
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(readFile).mockResolvedValue('# Post content');
+      vi.mocked(writeFile).mockImplementation(async (filePath, content) => {
+        writes[String(filePath)] = String(content);
+      });
+
+      const mockFetch = vi.fn();
+      global.fetch = mockFetch;
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        markSynced: true,
+        dryRun: false,
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(writes['/mock/vault/.notopress-sync.json']).toBeDefined();
+      const savedState = JSON.parse(writes['/mock/vault/.notopress-sync.json']);
+      expect(savedState.wordpress['post-one']).toBeDefined();
+      expect(savedState.wordpress['blog/post-two']).toBeDefined();
+    });
   });
 
   describe('restoreLocalImagePath', () => {

--- a/scripts/lib/wordpress.test.ts
+++ b/scripts/lib/wordpress.test.ts
@@ -586,9 +586,79 @@ describe('WordPress Deployment Library', () => {
       });
 
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Warning: Could not find posts in the vault matching slugs: "non-existent-slug"')
+        expect.stringContaining('Could not find posts in the vault matching slugs')
       );
       warnSpy.mockRestore();
+    });
+
+    it('should skip unchanged posts when content hash matches sync state', async () => {
+      const { computeContentHash } = await import('./sync-state');
+      const postContent = '# My Post Title\nThis is content.';
+      const hash = computeContentHash(postContent);
+
+      vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('.notopress-sync.json'));
+      vi.mocked(readFile).mockImplementation(async (p) => {
+        if (String(p).endsWith('.notopress-sync.json')) {
+          return JSON.stringify({
+            wordpress: {
+              'post-one': { contentHash: hash, syncedAt: '2026-07-27T00:00:00.000Z' },
+              'blog/post-two': { contentHash: hash, syncedAt: '2026-07-27T00:00:00.000Z' },
+            },
+          });
+        }
+        return postContent;
+      });
+
+      const mockFetch = vi.fn();
+      global.fetch = mockFetch;
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        dryRun: false,
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should push unchanged post when force is true', async () => {
+      const { computeContentHash } = await import('./sync-state');
+      const postContent = '# My Post Title\nThis is content.';
+      const hash = computeContentHash(postContent);
+
+      vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('.notopress-sync.json'));
+      vi.mocked(readFile).mockImplementation(async (p) => {
+        if (String(p).endsWith('.notopress-sync.json')) {
+          return JSON.stringify({
+            wordpress: {
+              'post-one': { contentHash: hash, syncedAt: '2026-07-27T00:00:00.000Z' },
+            },
+          });
+        }
+        return postContent;
+      });
+
+      const mockFetch = vi.fn().mockImplementation(async (url, options) => {
+        if (url.includes('/wp/v2/posts') && options.method === 'GET') {
+          return { ok: true, json: async () => [] };
+        }
+        if (url.includes('/wp/v2/posts') && options.method === 'POST') {
+          return { ok: true, json: async () => ({ id: 789 }) };
+        }
+        return { ok: false, status: 404 };
+      });
+      global.fetch = mockFetch;
+
+      await pushToWordPress({
+        site: mockSite,
+        registry: mockRegistry,
+        allIndices: mockIndices,
+        force: true,
+        dryRun: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalled();
     });
   });
 

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -22,6 +22,7 @@ interface PushToWordPressArgs {
   allIndices: Map<string, VaultDirectoryIndex>;
   targetSlugs?: string[];
   force?: boolean;
+  markSynced?: boolean;
   dryRun: boolean;
 }
 
@@ -152,6 +153,7 @@ export async function pushToWordPress({
   allIndices,
   targetSlugs,
   force,
+  markSynced,
   dryRun,
 }: PushToWordPressArgs) {
   const credentials = site.wordpress;
@@ -236,6 +238,27 @@ export async function pushToWordPress({
   }
 
   console.log(`Found ${postsToPublish.length} post(s) to process.`);
+
+  if (markSynced) {
+    console.log(`\n📝 Initializing WordPress Sync State (marking vault posts as synced)...`);
+    let markedCount = 0;
+    for (const post of postsToPublish) {
+      const fileContent = await readFile(post.localPath, 'utf-8');
+      const currentHash = computeContentHash(fileContent);
+      wpSyncState[post.slug] = {
+        contentHash: currentHash,
+        syncedAt: new Date().toISOString(),
+      };
+      markedCount += 1;
+      console.log(`  ✓ Marked "${post.title}" (slug: ${post.slug}) as synced.`);
+    }
+
+    if (!dryRun && markedCount > 0) {
+      await saveSyncState({ vaultPath: site.vaultPath, syncState });
+    }
+    console.log(`\n✅ Successfully marked ${markedCount} post(s) as synced in .notopress-sync.json.`);
+    return;
+  }
 
   let updatedCount = 0;
   let skippedCount = 0;

--- a/scripts/lib/wordpress.ts
+++ b/scripts/lib/wordpress.ts
@@ -13,11 +13,15 @@ import { type NoteReferenceInput } from '../../src/lib/note-links';
 import { collectNoteReferencesForLocalMarkdown, collectPrivateNoteIncludes } from './note-includes';
 
 
+import { computeContentHash, loadSyncState, saveSyncState } from './sync-state';
+
+
 interface PushToWordPressArgs {
   site: Site;
   registry: Registry;
   allIndices: Map<string, VaultDirectoryIndex>;
   targetSlugs?: string[];
+  force?: boolean;
   dryRun: boolean;
 }
 
@@ -147,6 +151,7 @@ export async function pushToWordPress({
   registry,
   allIndices,
   targetSlugs,
+  force,
   dryRun,
 }: PushToWordPressArgs) {
   const credentials = site.wordpress;
@@ -168,7 +173,14 @@ export async function pushToWordPress({
   if (targetSlugs && targetSlugs.length > 0) {
     console.log(`- Target Post Slugs: ${targetSlugs.join(', ')}`);
   }
+  if (force) {
+    console.log(`- Force Mode: ENABLED (Bypassing content hash checks)`);
+  }
   console.log(dryRun ? `- Mode: DRY RUN (No changes will be written)\n` : `- Mode: Live Sync\n`);
+
+  const syncState = await loadSyncState({ vaultPath: site.vaultPath });
+  const wpSyncState = syncState.wordpress || {};
+  syncState.wordpress = wpSyncState;
 
   // Load public files from root.json if it exists
   let assetFiles: string[] = [];
@@ -225,12 +237,26 @@ export async function pushToWordPress({
 
   console.log(`Found ${postsToPublish.length} post(s) to process.`);
 
+  let updatedCount = 0;
+  let skippedCount = 0;
+
   for (const post of postsToPublish) {
     try {
-      console.log(`\nSyncing "${post.title}" (slug: ${post.slug})...`);
-
       // Read markdown and parse frontmatter
       const fileContent = await readFile(post.localPath, 'utf-8');
+      const currentHash = computeContentHash(fileContent);
+
+      const isExplicitTarget = Boolean(targetSlugs && targetSlugs.length > 0);
+      const isAlreadySynced = wpSyncState[post.slug]?.contentHash === currentHash;
+
+      if (!force && !isExplicitTarget && isAlreadySynced) {
+        console.log(`  ⏭️  Skipping "${post.title}" (slug: ${post.slug}) - content unchanged.`);
+        skippedCount += 1;
+        continue;
+      }
+
+      console.log(`\nSyncing "${post.title}" (slug: ${post.slug})...`);
+
       const { data, content: markdownBody } = matter(fileContent);
       const wordpressResource = getWordPressRestResource({ frontmatter: data });
 
@@ -340,6 +366,12 @@ export async function pushToWordPress({
           console.log(`  ✅ Successfully CREATED new WordPress ${wordpressResource.contentType} (ID: ${newPost.id})`);
         }
       }
+
+      wpSyncState[post.slug] = {
+        contentHash: currentHash,
+        syncedAt: new Date().toISOString(),
+      };
+      updatedCount += 1;
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       console.error(`  ❌ Failed to sync post "${post.title}":`, errMsg);
@@ -348,6 +380,14 @@ export async function pushToWordPress({
         throw err;
       }
     }
+  }
+
+  if (!dryRun && updatedCount > 0) {
+    await saveSyncState({ vaultPath: site.vaultPath, syncState });
+  }
+
+  if (skippedCount > 0) {
+    console.log(`\n✨ WordPress sync complete: ${updatedCount} post(s) updated/created, ${skippedCount} post(s) skipped (unchanged).`);
   }
 }
 

--- a/src/templates/agent-rules/wordpress.md
+++ b/src/templates/agent-rules/wordpress.md
@@ -1,8 +1,9 @@
 # WordPress Integration & Commands
 - **Sync & Push Commands**:
-  - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp`: Syncs content vault and publishes Markdown posts to WordPress via REST API.
+  - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push`: Incrementally syncs content vault and pushes new/modified posts to WordPress (skipping unchanged posts).
   - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push <slug1,slug2>`: Publishes specific post slugs to WordPress.
-  - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --dry-run`: Previews WordPress API mutations without altering remote posts.
+  - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push --force`: Force updates all posts on WordPress regardless of content hash.
+  - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push --dry-run`: Previews WordPress API mutations without altering remote posts.
 - **Pull Commands**:
   - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --pull <slug-or-id>`: Fetches remote post from WordPress REST API, converts content, and saves to local vault Markdown.
 - **WP-CLI Utility Commands** (for managing local/remote WordPress instances):

--- a/src/templates/agent-rules/wordpress.md
+++ b/src/templates/agent-rules/wordpress.md
@@ -1,6 +1,7 @@
 # WordPress Integration & Commands
 - **Sync & Push Commands**:
   - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push`: Incrementally syncs content vault and pushes new/modified posts to WordPress (skipping unchanged posts).
+  - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --mark-synced`: Marks all current vault posts as synced in `.notopress-sync.json` without pushing to WordPress (useful on initial setup).
   - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push <slug1,slug2>`: Publishes specific post slugs to WordPress.
   - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push --force`: Force updates all posts on WordPress regardless of content hash.
   - `npm --prefix {{notopressPath}} run sync -- --site {{siteId}} --wp --push --dry-run`: Previews WordPress API mutations without altering remote posts.


### PR DESCRIPTION
## Summary

This PR adds **Automatic Incremental Push** support for WordPress publishing. Running `notopress sync --site <site-id> --wp --push` will now automatically detect new and modified posts by comparing SHA-256 content hashes, pushing only changed content to WordPress while skipping unmodified posts.

### 🚀 Key Features
* **Slug as Single Source of Truth**: Each post is tracked in `<vaultPath>/.notopress-sync.json` strictly by its canonical vault `slug` (e.g., `blog/post-one` -> `{ contentHash, syncedAt }`).
* **Content Hash Sync State**: Created `scripts/lib/sync-state.ts` to compute SHA-256 hashes of Markdown files. Unchanged posts are skipped locally without sending REST API GET/POST network calls to WordPress.
* **Explicit `--push` and `--force` Flags**:
  * `notopress sync --site <site> --wp --push`: Incrementally pushes new and updated posts.
  * `notopress sync --site <site> --wp --push <slug1,slug2>`: Pushes specific target slugs.
  * `notopress sync --site <site> --wp --push --force`: Force pushes all posts to WordPress regardless of content hash.
* **Updated Vault Rule Templates**: Updated `src/templates/agent-rules/wordpress.md` to document incremental `--push` and `--force` command usage for AI agents.

## Verification
- **Unit Tests**: All 113 tests passed across 14 test suites (`vitest`).
- **Type Check**: 0 type errors (`tsc --noEmit`).